### PR TITLE
Fix#15: redis stream 로직 분리 및 버그 수정

### DIFF
--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketValidator.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketValidator.java
@@ -1,6 +1,23 @@
 package com.wootecam.festivals.domain.ticket.entity;
 
-import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.*;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MAX_TICKET_DETAIL_LENGTH;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MAX_TICKET_NAME_LENGTH;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MAX_TICKET_PRICE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MAX_TICKET_QUANTITY;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MIN_TICKET_PRICE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MIN_TICKET_QUANTITY;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_DETAIL_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_END_TIME_EMPTY_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_END_TIME_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_FESTIVAL_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_NAME_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_PRICE_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_QUANTITY_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_REFUND_TIME_EMPTY_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_REFUND_TIME_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_START_TIME_EMPTY_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_START_TIME_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_TIME_VALID_MESSAGE;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import java.time.LocalDateTime;
@@ -87,7 +104,7 @@ public class TicketValidator {
             throw new IllegalArgumentException(TICKET_START_TIME_VALID_MESSAGE);
         }
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now().minusMinutes(1);
 
         if (now.isAfter(endSaleTime) || festival.getEndTime().isBefore(endSaleTime)) {
             throw new IllegalArgumentException(TICKET_END_TIME_VALID_MESSAGE);

--- a/backend/core/src/main/java/com/wootecam/festivals/global/config/RedisConfig.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/global/config/RedisConfig.java
@@ -1,12 +1,5 @@
 package com.wootecam.festivals.global.config;
 
-import static com.wootecam.festivals.domain.festival.constant.FestivalRedisStreamConstants.FESTIVAL_STREAM_GROUP;
-import static com.wootecam.festivals.domain.festival.constant.FestivalRedisStreamConstants.FESTIVAL_STREAM_KEY;
-import static com.wootecam.festivals.domain.ticket.constant.TicketRedisStreamConstants.TICKET_STREAM_GROUP;
-import static com.wootecam.festivals.domain.ticket.constant.TicketRedisStreamConstants.TICKET_STREAM_KEY;
-
-import com.wootecam.festivals.global.utils.RedisStreamOperator;
-import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,8 +14,6 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Profile("!test")
 public class RedisConfig {
 
-    private final RedisStreamOperator redisStreamOperator;
-
     @Value("${spring.data.redis.host}")
     private String redisHost;
 
@@ -32,11 +23,7 @@ public class RedisConfig {
     @Value("${spring.data.redis.password}")
     private String redisPassword;
 
-    public RedisConfig(RedisStreamOperator redisStreamOperator) {
-        this.redisStreamOperator = redisStreamOperator;
-    }
-
-    @Bean
+    @Bean(name = "redisConnectionFactory")
     @Profile("prod")
     public RedisConnectionFactory redisConnectionFactoryProd() {
         RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
@@ -47,7 +34,7 @@ public class RedisConfig {
         return new LettuceConnectionFactory(redisConfig);
     }
 
-    @Bean
+    @Bean(name = "redisConnectionFactory")
     @Profile("local")
     public RedisConnectionFactory redisConnectionFactoryLocal() {
         RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
@@ -66,11 +53,5 @@ public class RedisConfig {
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashValueSerializer(new StringRedisSerializer());
         return redisTemplate;
-    }
-
-    @PostConstruct
-    public void initStream() {
-        redisStreamOperator.createStreamConsumerGroup(FESTIVAL_STREAM_KEY, FESTIVAL_STREAM_GROUP);
-        redisStreamOperator.createStreamConsumerGroup(TICKET_STREAM_KEY, TICKET_STREAM_GROUP);
     }
 }

--- a/backend/core/src/main/java/com/wootecam/festivals/global/config/RedisStreamInitializer.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/global/config/RedisStreamInitializer.java
@@ -1,0 +1,47 @@
+package com.wootecam.festivals.global.config;
+
+import static com.wootecam.festivals.domain.festival.constant.FestivalRedisStreamConstants.FESTIVAL_STREAM_GROUP;
+import static com.wootecam.festivals.domain.festival.constant.FestivalRedisStreamConstants.FESTIVAL_STREAM_KEY;
+import static com.wootecam.festivals.domain.ticket.constant.TicketRedisStreamConstants.TICKET_STREAM_GROUP;
+import static com.wootecam.festivals.domain.ticket.constant.TicketRedisStreamConstants.TICKET_STREAM_KEY;
+
+import com.wootecam.festivals.global.utils.RedisStreamOperator;
+import jakarta.annotation.PostConstruct;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisStreamInitializer {
+
+    private static final String LOCK_KEY = "lock_key";
+
+    private final StringRedisTemplate redisTemplate;
+    private final RedisStreamOperator redisStreamOperator;
+
+    @PostConstruct
+    public void initStreams() {
+        // 초기화 동시 실행 방지
+        boolean locked = Boolean.TRUE.equals(
+                redisTemplate.opsForValue().setIfAbsent(LOCK_KEY, "locked", Duration.ofSeconds(30)));
+        if (!locked) {
+            log.info("다른 프로세스에서 이미 초기화 중입니다. 초기화를 건너뜁니다.");
+            return;
+        }
+
+        // 스트림 및 소비자 그룹 초기화
+        initializeStream(FESTIVAL_STREAM_KEY, FESTIVAL_STREAM_GROUP);
+        initializeStream(TICKET_STREAM_KEY, TICKET_STREAM_GROUP);
+    }
+
+    private void initializeStream(String streamKey, String groupName) {
+        log.info("Stream {} 초기화 시도", streamKey);
+        log.info("Consumer Group {} 초기화 시도", groupName);
+
+        redisStreamOperator.createStreamConsumerGroup(streamKey, groupName);
+    }
+}

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketValidator.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketValidator.java
@@ -1,6 +1,23 @@
 package com.wootecam.festivals.domain.ticket.entity;
 
-import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.*;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MAX_TICKET_DETAIL_LENGTH;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MAX_TICKET_NAME_LENGTH;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MAX_TICKET_PRICE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MAX_TICKET_QUANTITY;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MIN_TICKET_PRICE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.MIN_TICKET_QUANTITY;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_DETAIL_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_END_TIME_EMPTY_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_END_TIME_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_FESTIVAL_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_NAME_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_PRICE_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_QUANTITY_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_REFUND_TIME_EMPTY_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_REFUND_TIME_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_START_TIME_EMPTY_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_START_TIME_VALID_MESSAGE;
+import static com.wootecam.festivals.domain.ticket.entity.TicketValidConstant.TICKET_TIME_VALID_MESSAGE;
 
 import com.wootecam.festivals.domain.festival.entity.Festival;
 import java.time.LocalDateTime;
@@ -87,7 +104,7 @@ public class TicketValidator {
             throw new IllegalArgumentException(TICKET_START_TIME_VALID_MESSAGE);
         }
 
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = LocalDateTime.now().minusMinutes(1);
 
         if (now.isAfter(endSaleTime) || festival.getEndTime().isBefore(endSaleTime)) {
             throw new IllegalArgumentException(TICKET_END_TIME_VALID_MESSAGE);


### PR DESCRIPTION
## 📄 작업 설명
redis stream 로직 초기화 시 순환 참조가 일어나던 문제를 해결했어요 !
또한 RedisConnectionFactory 빈을 찾지 못하는 버그를 빈 이름을 명시해줌으로써 해결해줬습니다.
정적 스케줄링을 통해 stream pending message를 claim하는 로직에 로깅을 추가했습니다 !
티켓 유효성 검사 시 네트워크 시간을 생각해서 1분의 여유를 두고 검사하는 로직을 추가했어요 !
## 🚨 관련 이슈
closes #15 

## 🌈 작업 상황
- RedisConnectionFactory을 찾지 못하는 버그 해결
- redis stream 로직 순환 참조 문제 해결
- 로깅 추가
- 유효성 검사 시 네트워크 시간을 생각해 1분 여유를 두는 로직 추가
## 📌 기타
