### PR TITLE
Feat#18: SQL 초기화 스크립트 추가 #18

### DIFF
--- a/backend/api-server/src/main/resources/application.yml
+++ b/backend/api-server/src/main/resources/application.yml
@@ -154,7 +154,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       TZ: Asia/Seoul
     volumes:
       - mysql_data:/var/lib/mysql
+      - ./mysql/init/:/docker-entrypoint-initdb.d/  # 초기화 SQL 파일 마운트
     networks:
       - app-network
 

--- a/backend/mysql/init/init.sql
+++ b/backend/mysql/init/init.sql
@@ -1,0 +1,752 @@
+create table if not exists twodari.checkin
+(
+    is_checked
+    bit
+    not
+    null,
+    checkin_id
+    bigint
+    auto_increment
+    primary
+    key,
+    checkin_time
+    datetime
+(
+    6
+) null,
+    created_at datetime
+(
+    6
+) not null,
+    festival_id bigint not null,
+    member_id bigint not null,
+    ticket_id bigint not null,
+    updated_at datetime
+(
+    6
+) not null
+    );
+
+create index checkin_festival_id_index
+    on twodari.checkin (festival_id);
+
+create index checkin_member_id_index
+    on twodari.checkin (member_id);
+
+create index checkin_ticket_id_index
+    on twodari.checkin (ticket_id);
+
+create table if not exists twodari.festival
+(
+    is_deleted
+    bit
+    not
+    null,
+    admin_id
+    bigint
+    not
+    null,
+    created_at
+    datetime
+(
+    6
+) null,
+    festival_end_time datetime
+(
+    6
+) not null,
+    festival_id bigint auto_increment
+    primary key,
+    festival_start_time datetime
+(
+    6
+) not null,
+    updated_at datetime
+(
+    6
+) null,
+    festival_title varchar
+(
+    100
+) not null,
+    festival_description varchar
+(
+    2000
+) not null,
+    festival_img varchar
+(
+    255
+) null,
+    festival_progress_status enum
+(
+    'COMPLETED',
+    'ONGOING',
+    'UPCOMING'
+) not null,
+    festival_publication_status enum
+(
+    'DRAFT',
+    'PUBLISHED'
+) not null
+    );
+
+create index festival_admin_id_index
+    on twodari.festival (admin_id);
+
+create table if not exists twodari.member
+(
+    is_deleted
+    bit
+    not
+    null,
+    created_at
+    datetime
+(
+    6
+) null,
+    member_id bigint auto_increment
+    primary key,
+    updated_at datetime
+(
+    6
+) null,
+    email varchar
+(
+    255
+) not null,
+    member_name varchar
+(
+    255
+) not null,
+    profile_img varchar
+(
+    255
+) null,
+    constraint UKmbmcqelty0fbrvxp1q58dn57t
+    unique
+(
+    email
+)
+    );
+
+create table if not exists twodari.purchase
+(
+    created_at
+    datetime
+(
+    6
+) not null,
+    member_id bigint not null,
+    purchase_id bigint auto_increment
+    primary key,
+    purchase_time datetime
+(
+    6
+) not null,
+    ticket_id bigint not null,
+    updated_at datetime
+(
+    6
+) not null,
+    purchase_status enum
+(
+    'PURCHASED',
+    'REFUNDED'
+) not null
+    );
+
+create index purchase_member_id_index
+    on twodari.purchase (member_id);
+
+create index purchase_ticket_id_index
+    on twodari.purchase (ticket_id);
+
+create table if not exists twodari.ticket
+(
+    is_deleted
+    bit
+    not
+    null,
+    ticket_quantity
+    int
+    not
+    null,
+    created_at
+    datetime
+(
+    6
+) null,
+    end_refund_time datetime
+(
+    6
+) not null,
+    end_sale_time datetime
+(
+    6
+) not null,
+    festival_id bigint not null,
+    start_sale_time datetime
+(
+    6
+) not null,
+    ticket_id bigint auto_increment
+    primary key,
+    ticket_price bigint not null,
+    updated_at datetime
+(
+    6
+) null,
+    ticket_detail varchar
+(
+    255
+) not null,
+    ticket_name varchar
+(
+    255
+) not null
+    );
+
+create index ticket_festival_id_index
+    on twodari.ticket (festival_id);
+
+create table if not exists twodari.ticket_stock
+(
+    ticket_stock_id
+    bigint
+    auto_increment
+    primary
+    key,
+    ticket_id
+    bigint
+    not
+    null,
+    ticket_stock_member_id
+    bigint
+    null,
+    created_at
+    datetime
+(
+    6
+) not null,
+    updated_at datetime
+(
+    6
+) not null
+    );
+
+create unique index ticket_stock_ticket_id_ticket_stock_member_id_index
+    on twodari.ticket_stock (ticket_id, ticket_stock_member_id);
+
+
+CREATE
+DATABASE IF NOT EXISTS schedule;
+USE
+schedule;
+
+CREATE TABLE IF NOT EXISTS QRTZ_JOB_DETAILS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    JOB_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    JOB_GROUP VARCHAR
+(
+    190
+) NOT NULL,
+    DESCRIPTION VARCHAR
+(
+    250
+) NULL,
+    JOB_CLASS_NAME VARCHAR
+(
+    250
+) NOT NULL,
+    IS_DURABLE VARCHAR
+(
+    1
+) NOT NULL,
+    IS_NONCONCURRENT VARCHAR
+(
+    1
+) NOT NULL,
+    IS_UPDATE_DATA VARCHAR
+(
+    1
+) NOT NULL,
+    REQUESTS_RECOVERY VARCHAR
+(
+    1
+) NOT NULL,
+    JOB_DATA BLOB NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    JOB_NAME,
+    JOB_GROUP
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_TRIGGERS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    TRIGGER_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    TRIGGER_GROUP VARCHAR
+(
+    190
+) NOT NULL,
+    JOB_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    JOB_GROUP VARCHAR
+(
+    190
+) NOT NULL,
+    DESCRIPTION VARCHAR
+(
+    250
+) NULL,
+    NEXT_FIRE_TIME BIGINT
+(
+    13
+) NULL,
+    PREV_FIRE_TIME BIGINT
+(
+    13
+) NULL,
+    PRIORITY INTEGER NULL,
+    TRIGGER_STATE VARCHAR
+(
+    16
+) NOT NULL,
+    TRIGGER_TYPE VARCHAR
+(
+    8
+) NOT NULL,
+    START_TIME BIGINT
+(
+    13
+) NOT NULL,
+    END_TIME BIGINT
+(
+    13
+) NULL,
+    CALENDAR_NAME VARCHAR
+(
+    190
+) NULL,
+    MISFIRE_INSTR SMALLINT
+(
+    2
+) NULL,
+    JOB_DATA BLOB NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+),
+    FOREIGN KEY
+(
+    SCHED_NAME,
+    JOB_NAME,
+    JOB_GROUP
+)
+    REFERENCES QRTZ_JOB_DETAILS
+(
+    SCHED_NAME,
+    JOB_NAME,
+    JOB_GROUP
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_SIMPLE_TRIGGERS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    TRIGGER_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    TRIGGER_GROUP VARCHAR
+(
+    190
+) NOT NULL,
+    REPEAT_COUNT BIGINT
+(
+    7
+) NOT NULL,
+    REPEAT_INTERVAL BIGINT
+(
+    12
+) NOT NULL,
+    TIMES_TRIGGERED BIGINT
+(
+    10
+) NOT NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+),
+    FOREIGN KEY
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+)
+    REFERENCES QRTZ_TRIGGERS
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_CRON_TRIGGERS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    TRIGGER_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    TRIGGER_GROUP VARCHAR
+(
+    190
+) NOT NULL,
+    CRON_EXPRESSION VARCHAR
+(
+    120
+) NOT NULL,
+    TIME_ZONE_ID VARCHAR
+(
+    80
+),
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+),
+    FOREIGN KEY
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+)
+    REFERENCES QRTZ_TRIGGERS
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_SIMPROP_TRIGGERS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    TRIGGER_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    TRIGGER_GROUP VARCHAR
+(
+    190
+) NOT NULL,
+    STR_PROP_1 VARCHAR
+(
+    512
+) NULL,
+    STR_PROP_2 VARCHAR
+(
+    512
+) NULL,
+    STR_PROP_3 VARCHAR
+(
+    512
+) NULL,
+    INT_PROP_1 INT NULL,
+    INT_PROP_2 INT NULL,
+    LONG_PROP_1 BIGINT NULL,
+    LONG_PROP_2 BIGINT NULL,
+    DEC_PROP_1 NUMERIC
+(
+    13,
+    4
+) NULL,
+    DEC_PROP_2 NUMERIC
+(
+    13,
+    4
+) NULL,
+    BOOL_PROP_1 VARCHAR
+(
+    1
+) NULL,
+    BOOL_PROP_2 VARCHAR
+(
+    1
+) NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+),
+    FOREIGN KEY
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+)
+    REFERENCES QRTZ_TRIGGERS
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_BLOB_TRIGGERS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    TRIGGER_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    TRIGGER_GROUP VARCHAR
+(
+    190
+) NOT NULL,
+    BLOB_DATA BLOB NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+),
+    INDEX
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+),
+    FOREIGN KEY
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+)
+    REFERENCES QRTZ_TRIGGERS
+(
+    SCHED_NAME,
+    TRIGGER_NAME,
+    TRIGGER_GROUP
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_CALENDARS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    CALENDAR_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    CALENDAR BLOB NOT NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    CALENDAR_NAME
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_PAUSED_TRIGGER_GRPS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    TRIGGER_GROUP VARCHAR
+(
+    190
+) NOT NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    TRIGGER_GROUP
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_FIRED_TRIGGERS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    ENTRY_ID VARCHAR
+(
+    95
+) NOT NULL,
+    TRIGGER_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    TRIGGER_GROUP VARCHAR
+(
+    190
+) NOT NULL,
+    INSTANCE_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    FIRED_TIME BIGINT
+(
+    13
+) NOT NULL,
+    SCHED_TIME BIGINT
+(
+    13
+) NOT NULL,
+    PRIORITY INTEGER NOT NULL,
+    STATE VARCHAR
+(
+    16
+) NOT NULL,
+    JOB_NAME VARCHAR
+(
+    190
+) NULL,
+    JOB_GROUP VARCHAR
+(
+    190
+) NULL,
+    IS_NONCONCURRENT VARCHAR
+(
+    1
+) NULL,
+    REQUESTS_RECOVERY VARCHAR
+(
+    1
+) NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    ENTRY_ID
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_SCHEDULER_STATE
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    INSTANCE_NAME VARCHAR
+(
+    190
+) NOT NULL,
+    LAST_CHECKIN_TIME BIGINT
+(
+    13
+) NOT NULL,
+    CHECKIN_INTERVAL BIGINT
+(
+    13
+) NOT NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    INSTANCE_NAME
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE TABLE IF NOT EXISTS QRTZ_LOCKS
+(
+    SCHED_NAME
+    VARCHAR
+(
+    120
+) NOT NULL,
+    LOCK_NAME VARCHAR
+(
+    40
+) NOT NULL,
+    PRIMARY KEY
+(
+    SCHED_NAME,
+    LOCK_NAME
+)
+    )
+    ENGINE = InnoDB;
+
+CREATE INDEX IDX_QRTZ_J_REQ_RECOVERY ON QRTZ_JOB_DETAILS (SCHED_NAME, REQUESTS_RECOVERY);
+CREATE INDEX IDX_QRTZ_J_GRP ON QRTZ_JOB_DETAILS (SCHED_NAME, JOB_GROUP);
+
+CREATE INDEX IDX_QRTZ_T_J ON QRTZ_TRIGGERS (SCHED_NAME, JOB_NAME, JOB_GROUP);
+CREATE INDEX IDX_QRTZ_T_JG ON QRTZ_TRIGGERS (SCHED_NAME, JOB_GROUP);
+CREATE INDEX IDX_QRTZ_T_C ON QRTZ_TRIGGERS (SCHED_NAME, CALENDAR_NAME);
+CREATE INDEX IDX_QRTZ_T_G ON QRTZ_TRIGGERS (SCHED_NAME, TRIGGER_GROUP);
+CREATE INDEX IDX_QRTZ_T_STATE ON QRTZ_TRIGGERS (SCHED_NAME, TRIGGER_STATE);
+CREATE INDEX IDX_QRTZ_T_N_STATE ON QRTZ_TRIGGERS (SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP, TRIGGER_STATE);
+CREATE INDEX IDX_QRTZ_T_N_G_STATE ON QRTZ_TRIGGERS (SCHED_NAME, TRIGGER_GROUP, TRIGGER_STATE);
+CREATE INDEX IDX_QRTZ_T_NEXT_FIRE_TIME ON QRTZ_TRIGGERS (SCHED_NAME, NEXT_FIRE_TIME);
+CREATE INDEX IDX_QRTZ_T_NFT_ST ON QRTZ_TRIGGERS (SCHED_NAME, TRIGGER_STATE, NEXT_FIRE_TIME);
+CREATE INDEX IDX_QRTZ_T_NFT_MISFIRE ON QRTZ_TRIGGERS (SCHED_NAME, MISFIRE_INSTR, NEXT_FIRE_TIME);
+CREATE INDEX IDX_QRTZ_T_NFT_ST_MISFIRE ON QRTZ_TRIGGERS (SCHED_NAME, MISFIRE_INSTR, NEXT_FIRE_TIME, TRIGGER_STATE);
+CREATE INDEX IDX_QRTZ_T_NFT_ST_MISFIRE_GRP ON QRTZ_TRIGGERS (SCHED_NAME, MISFIRE_INSTR, NEXT_FIRE_TIME, TRIGGER_GROUP,
+                                                             TRIGGER_STATE);
+
+CREATE INDEX IDX_QRTZ_FT_TRIG_INST_NAME ON QRTZ_FIRED_TRIGGERS (SCHED_NAME, INSTANCE_NAME);
+CREATE INDEX IDX_QRTZ_FT_INST_JOB_REQ_RCVRY ON QRTZ_FIRED_TRIGGERS (SCHED_NAME, INSTANCE_NAME, REQUESTS_RECOVERY);
+CREATE INDEX IDX_QRTZ_FT_J_G ON QRTZ_FIRED_TRIGGERS (SCHED_NAME, JOB_NAME, JOB_GROUP);
+CREATE INDEX IDX_QRTZ_FT_JG ON QRTZ_FIRED_TRIGGERS (SCHED_NAME, JOB_GROUP);
+CREATE INDEX IDX_QRTZ_FT_T_G ON QRTZ_FIRED_TRIGGERS (SCHED_NAME, TRIGGER_NAME, TRIGGER_GROUP);
+CREATE INDEX IDX_QRTZ_FT_TG ON QRTZ_FIRED_TRIGGERS (SCHED_NAME, TRIGGER_GROUP);
+
+commit;
+

--- a/backend/schedule-server/src/main/resources/application.yml
+++ b/backend/schedule-server/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
     scheduler-name: quartzScheduler
     job-store-type: jdbc
     jdbc:
-      initialize-schema: always
+      initialize-schema: never
     properties:
       org.quartz:
         scheduler:
@@ -159,7 +159,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:
@@ -171,7 +171,7 @@ spring:
     scheduler-name: quartzScheduler
     job-store-type: jdbc
     jdbc:
-      initialize-schema: always
+      initialize-schema: never
     properties:
       org.quartz:
         scheduler:
@@ -183,8 +183,8 @@ spring:
           useProperties: false
           dataSource: schedule
           isClustered: true
-          misfireThreshold: 30000
-          clusterCheckinInterval: 10000
+          misfireThreshold: 10000
+          clusterCheckinInterval: 5000
           tablePrefix: QRTZ_ # Quartz 테이블 이름 접두사
         dataSource:
           schedule:


### PR DESCRIPTION
## 📄 작업 설명
MySQL DDL 충돌 이슈로 테이블을 여러번 만들던 현상을 해결하기 위해 SQL 초기화 스크립트를 컨테이너 실행 시 넣도록 했습니다.

## 🚨 관련 이슈
closes #18 

## 🌈 작업 상황
- init.sql 추가
- docker compose 스크립트 변경

## 📌 기타
