### PR TITLE
Feat#22: 웹소켓 모듈 기본 설정 및 인증 로직 구현

### DIFF
--- a/backend/core/src/main/java/com/wootecam/festivals/global/utils/AuthenticationUtils.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/global/utils/AuthenticationUtils.java
@@ -28,6 +28,6 @@ public final class AuthenticationUtils {
         HttpSession session = getSession();
         logger.debug("Authentication set: {}", authentication);
 
-        session.setAttribute("AUTHENTICATION", authentication);
+        session.setAttribute(AUTHENTICATION, authentication);
     }
 }

--- a/backend/core/src/main/java/com/wootecam/festivals/global/utils/AuthenticationUtils.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/global/utils/AuthenticationUtils.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 public final class AuthenticationUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(AuthenticationUtils.class);
+    public static final String AUTHENTICATION = "authentication";
 
     private AuthenticationUtils() {
     }
@@ -18,7 +19,7 @@ public final class AuthenticationUtils {
     public static Authentication getAuthentication() {
         HttpSession session = getExistSession();
         if (session != null) {
-            return (Authentication) session.getAttribute("authentication");
+            return (Authentication) session.getAttribute(AUTHENTICATION);
         }
         return null;
     }
@@ -27,6 +28,6 @@ public final class AuthenticationUtils {
         HttpSession session = getSession();
         logger.debug("Authentication set: {}", authentication);
 
-        session.setAttribute("authentication", authentication);
+        session.setAttribute("AUTHENTICATION", authentication);
     }
 }

--- a/backend/queue-server/build.gradle
+++ b/backend/queue-server/build.gradle
@@ -1,2 +1,7 @@
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-websocket'
 }

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/AuthUser.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/AuthUser.java
@@ -1,0 +1,11 @@
+package com.wootecam.festivals.global.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthUser {
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/WebSocketAuthArgumentResolver.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/WebSocketAuthArgumentResolver.java
@@ -1,0 +1,78 @@
+package com.wootecam.festivals.global.auth;
+
+import com.wootecam.festivals.global.exception.WebSocketException;
+import com.wootecam.festivals.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.stereotype.Component;
+
+/**
+ * WebSocket 메시지 핸들러에서 인증된 사용자 정보를 자동으로 주입하는 Argument Resolver.
+ *
+ * <p>
+ * - WebSocket 메시지에서 `Authorization` 헤더에 포함된 JWT를 검증하여 사용자 정보를 추출한다. - 인증된 사용자의 `memberId`를 컨트롤러 메서드의 `@AuthUser` 파라미터로
+ * 자동 주입한다. - 인증되지 않은 사용자는 예외를 발생시켜 메시지 처리를 차단한다.
+ * </p>
+ *
+ * @author 김현준
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class WebSocketAuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtProvider jwtProvider;
+
+    /**
+     * 해당 파라미터가 `@AuthUser` 어노테이션이 붙어 있고, `Long` 타입이면 지원하는지 확인.
+     *
+     * <p>
+     * - WebSocket 컨트롤러의 특정 파라미터가 `@AuthUser` 어노테이션을 포함하고 있는지 확인한다. - 파라미터 타입이 `Long`이면 이 Argument Resolver가 처리하도록
+     * 허용한다.
+     * </p>
+     *
+     * @param parameter 검사할 메서드 파라미터
+     * @return `@AuthUser`가 선언된 `Long` 타입 파라미터이면 `true`, 그렇지 않으면 `false`
+     */
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthUser.class) &&
+                Long.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    /**
+     * WebSocket 메시지에서 인증 정보를 가져오는 Argument Resolver.
+     *
+     * <p>
+     * - WebSocket 메시지 헤더에서 `Authorization` 값을 추출하여 JWT를 검증한다. - `Authorization` 헤더의 값이 "Bearer {JWT}" 형식인지 확인한다. -
+     * JWT에서 사용자 ID를 추출하고 컨트롤러 메서드의 `@AuthUser` 파라미터에 전달한다. - 인증되지 않은 사용자는 `WebSocketException`을 발생시켜 메시지 처리를 차단한다.
+     * </p>
+     *
+     * @param parameter 컨트롤러 메서드의 파라미터 정보
+     * @param message   WebSocket 메시지 객체
+     * @return 인증된 사용자의 `memberId` (`Long` 타입)
+     * @throws WebSocketException JWT가 없거나 유효하지 않은 경우 예외 발생
+     */
+    @Override
+    public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+        // WebSocket 메시지 헤더에서 `Authorization` 값 가져오기
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(message);
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+
+        // JWT 토큰이 없거나 "Bearer " 형식이 아닌 경우 예외 발생
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new WebSocketException(AuthErrorCode.UNAUTHORIZED, "인증 토큰이 존재하지 않습니다.");
+        }
+
+        // "Bearer " 접두사를 제거하고 JWT 토큰만 추출
+        String token = authHeader.substring(7);
+
+        // JWT에서 사용자 ID 추출 및 반환
+        return jwtProvider.getMemberIdFromToken(token);
+    }
+
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptor.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptor.java
@@ -1,0 +1,82 @@
+package com.wootecam.festivals.global.auth.interceptor;
+
+import com.wootecam.festivals.global.auth.Authentication;
+import com.wootecam.festivals.global.jwt.JwtProvider;
+import com.wootecam.festivals.global.utils.AuthenticationUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+/**
+ * WebSocket 연결 시 인증을 처리하는 인터셉터.
+ * <p>
+ * - WebSocket 핸드셰이크 과정에서 사용자의 인증 정보를 확인하고, 인증되지 않은 사용자의 연결을 차단한다. - 인증된 사용자의 정보를 WebSocket 세션 속성에 저장하여 이후 WebSocket
+ * 통신에서 활용할 수 있도록 한다.
+ * </p>
+ *
+ * @author 김현준
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthInterceptor implements HandshakeInterceptor {
+
+    private final JwtProvider jwtProvider;
+
+    /**
+     * WebSocket 핸드셰이크 요청을 가로채어 인증을 수행하는 메서드.
+     * <p>
+     * - 인증된 사용자의 ID를 WebSocket 세션 속성에 저장. - 인증되지 않은 사용자는 HTTP 401 응답을 반환하며 연결을 차단.
+     * </p>
+     *
+     * @param request    WebSocket 핸드셰이크 요청 객체
+     * @param response   WebSocket 핸드셰이크 응답 객체
+     * @param wsHandler  WebSocket 핸들러
+     * @param attributes WebSocket 세션 속성 (인증된 사용자 ID 저장)
+     * @return 인증이 성공하면 true, 실패하면 false
+     * @throws Exception 예외 발생 시 WebSocket 연결 차단
+     */
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+                                   WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        if (!(request instanceof ServletServerHttpRequest servletServerHttpRequest)) {
+            response.setStatusCode(HttpStatus.UNAUTHORIZED);
+            return false;
+        }
+
+        HttpServletRequest httpServletRequest = servletServerHttpRequest.getServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(httpServletRequest));
+
+        Authentication authentication = AuthenticationUtils.getAuthentication();
+
+        if (authentication == null) {
+            log.warn("WebSocket 인증 실패 - 인증 정보 없음");
+            response.setStatusCode(HttpStatus.UNAUTHORIZED);
+            return false;
+        }
+
+        // JWT 생성 및 응답 헤더에 추가
+        String jwtToken = jwtProvider.generateToken(authentication.memberId());
+        response.getHeaders().add("Set-Cookie", "WebSocket-Token=" + jwtToken + "; Path=/; HttpOnly; Secure");
+
+        log.info("WebSocket 인증 성공: {}", authentication);
+
+        return true;
+    }
+
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler,
+                               Exception exception) {
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptor.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptor.java
@@ -67,7 +67,7 @@ public class WebSocketAuthInterceptor implements HandshakeInterceptor {
 
         // JWT 생성 및 응답 헤더에 추가
         String jwtToken = jwtProvider.generateToken(authentication.memberId());
-        response.getHeaders().add("Set-Cookie", "WebSocket-Token=" + jwtToken + "; Path=/; HttpOnly; Secure");
+        response.getHeaders().add("Authorization", jwtToken);
 
         log.info("WebSocket 인증 성공: {}", authentication);
 

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptor.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptor.java
@@ -1,5 +1,7 @@
 package com.wootecam.festivals.global.auth.interceptor;
 
+import static com.wootecam.festivals.global.jwt.JwtProvider.ACCESS_TOKEN_VALIDITY;
+
 import com.wootecam.festivals.global.auth.Authentication;
 import com.wootecam.festivals.global.jwt.JwtProvider;
 import com.wootecam.festivals.global.utils.AuthenticationUtils;
@@ -66,7 +68,7 @@ public class WebSocketAuthInterceptor implements HandshakeInterceptor {
         }
 
         // JWT 생성 및 응답 헤더에 추가
-        String jwtToken = jwtProvider.generateToken(authentication.memberId());
+        String jwtToken = jwtProvider.generateToken(authentication.memberId(), ACCESS_TOKEN_VALIDITY);
         response.getHeaders().add("Authorization", jwtToken);
 
         log.info("WebSocket 인증 성공: {}", authentication);

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/config/WebSocketConfig.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/config/WebSocketConfig.java
@@ -1,0 +1,103 @@
+package com.wootecam.festivals.global.config;
+
+import com.wootecam.festivals.global.auth.WebSocketAuthArgumentResolver;
+import com.wootecam.festivals.global.auth.interceptor.WebSocketAuthInterceptor;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * WebSocket 및 STOMP 설정을 담당하는 클래스.
+ *
+ * <p>
+ * - WebSocket을 사용하여 클라이언트와 서버 간의 실시간 통신을 지원합니다. - STOMP 프로토콜을 활용한 Pub/Sub 모델을 적용하여 메시지 브로커를 구성합니다. - Spring Session을
+ * 활용하여 WebSocket과 HTTP 세션을 공유할 수 있도록 설정합니다. - `AuthArgumentResolver`를 추가하여 컨트롤러 핸들러 메서드에서 인증된 사용자 정보를 주입할 수 있도록 지원합니다.
+ * - `heartbeat` 설정을 추가하여 클라이언트와 서버 간의 연결을 유지하고, 비정상 종료된 세션을 감지할 수 있도록 합니다.
+ * </p>
+ *
+ * @author 김현준
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final WebSocketAuthArgumentResolver authArgumentResolver;
+    private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+
+    /**
+     * WebSocket 엔드포인트를 등록하여 클라이언트가 서버와 연결할 수 있도록 설정합니다.
+     *
+     * <p>
+     * - 클라이언트는 `ws://server.com/ws`를 통해 WebSocket에 연결할 수 있습니다. - CORS 허용을 위해 `setAllowedOriginPatterns("*")`을 추가하여 다양한
+     * 도메인에서 접근할 수 있도록 설정합니다. - Spring Session을 활용하여 HTTP 세션과 WebSocket 세션을 공유할 수 있도록 구성됩니다.
+     * </p>
+     *
+     * @param registry STOMP 엔드포인트를 등록할 레지스트리 객체
+     */
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws") // 클라이언트가 연결할 WebSocket 엔드포인트
+                .setAllowedOriginPatterns("*") // CORS 설정: 모든 도메인에서 접근 가능
+                .addInterceptors(webSocketAuthInterceptor);
+    }
+
+    /**
+     * 메시지 브로커를 설정하여 클라이언트 간 메시지 전송을 가능하게 합니다.
+     *
+     * <p>
+     * - `/app`으로 시작하는 메시지는 애플리케이션 내부에서 처리됩니다. - `/topic`과 `/queue`로 시작하는 메시지는 메시지 브로커를 통해 전달됩니다. - `/user/queue/`는 특정
+     * 사용자에게 메시지를 보내는 데 사용됩니다. - `heartbeat` 설정을 추가하여 서버와 클라이언트 간 연결을 유지하고, 비정상 종료된 세션을 감지할 수 있도록 합니다.
+     * </p>
+     *
+     * @param registry 메시지 브로커 설정 객체
+     */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic", "/queue") // 메시지 브로커 활성화
+                .setHeartbeatValue(new long[]{10000, 10000}) // 10초마다 하트비트 전송 설정
+                .setTaskScheduler(heartBeatTaskScheduler()); // 하트비트 관리용 스레드 풀 사용
+        registry.setApplicationDestinationPrefixes("/app"); // 클라이언트가 보낼 메시지의 prefix 설정
+        registry.setUserDestinationPrefix("/user"); // 특정 사용자에게 메시지를 보낼 때 사용
+    }
+
+    /**
+     * WebSocket 메시지 핸들러에서 사용자 인증 정보를 자동으로 주입하는 Argument Resolver를 추가합니다.
+     *
+     * <p>
+     * - `@AuthUser` 어노테이션이 있는 컨트롤러의 파라미터에 `memberId`를 자동 주입하여 활용할 수 있습니다.
+     * </p>
+     *
+     * @param argumentResolvers 메시지 핸들러에서 사용할 Argument Resolver 리스트
+     */
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(authArgumentResolver);
+    }
+
+    /**
+     * TaskScheduler 빈을 등록하여 WebSocket의 Heartbeat 기능을 지원합니다.
+     *
+     * <p>
+     * - `heartbeat`을 설정하면 주기적으로 서버와 클라이언트 간의 연결 상태를 확인해야 합니다. - Spring의 `ThreadPoolTaskScheduler`를 사용하여 heartbeat 작업을
+     * 처리합니다. - 풀 크기를 5로 설정하여 다중 연결을 효율적으로 관리하도록 구성합니다.
+     * </p>
+     *
+     * @return `ThreadPoolTaskScheduler` 인스턴스
+     */
+    @Bean
+    public ThreadPoolTaskScheduler heartBeatTaskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.setThreadNamePrefix("wss-heartbeat-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/exception/WebSocketErrorResponse.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/exception/WebSocketErrorResponse.java
@@ -1,0 +1,15 @@
+package com.wootecam.festivals.global.exception;
+
+public class WebSocketErrorResponse {
+    private final String errorCode;
+    private final String message;
+
+    public WebSocketErrorResponse(String errorCode, String message) {
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+
+    public static WebSocketErrorResponse of(String errorCode, String message) {
+        return new WebSocketErrorResponse(errorCode, message);
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/exception/WebSocketException.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/exception/WebSocketException.java
@@ -1,0 +1,36 @@
+package com.wootecam.festivals.global.exception;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class WebSocketException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String errorDescription;
+
+    public WebSocketException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.errorDescription = errorCode.getMessage();
+    }
+
+    public WebSocketException(ErrorCode errorCode, String errorDescription) {
+        super(errorDescription);
+        this.errorCode = errorCode;
+        this.errorDescription = errorDescription;
+    }
+
+    public WebSocketException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+        this.errorDescription = errorCode.getMessage();
+    }
+
+    public WebSocketException(ErrorCode errorCode, String errorDescription, Throwable cause) {
+        super(errorDescription, cause);
+        this.errorCode = errorCode;
+        this.errorDescription = errorDescription;
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/exception/WebSocketExceptionHandler.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/exception/WebSocketExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.wootecam.festivals.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.stereotype.Controller;
+
+/**
+ * WebSocket 통신 중 발생하는 예외를 처리하는 핸들러.
+ * <p>
+ * - WebSocket 메시지 처리 중 발생하는 `WebSocketException`을 처리하여 클라이언트에게 전송한다.
+ * - `@SendToUser(destinations = "/queue/errors", broadcast = false)`를 사용하여 발생한 예외 메시지를 해당 클라이언트에게만 전송한다.
+ * - 발생한 예외 정보를 로그로 기록한다.
+ * </p>
+ *
+ * @author 김현준
+ */
+@Controller
+@Slf4j
+public class WebSocketExceptionHandler {
+
+    /**
+     * WebSocket 메시지 처리 중 발생한 `WebSocketException`을 처리하는 메서드.
+     * <p>
+     * - `@MessageExceptionHandler(WebSocketException.class)`를 사용하여 예외를 감지한다.
+     * - `@SendToUser(destinations = "/queue/errors", broadcast = false)`를 사용하여 해당 요청을 보낸 사용자에게만 예외 메시지를 전송한다.
+     * - 발생한 예외 정보를 로그로 기록한다.
+     * </p>
+     *
+     * @param exception 발생한 `WebSocketException` 객체
+     * @return 클라이언트에게 전송할 `WebSocketErrorResponse` 객체 (JSON 응답)
+     */
+    @MessageExceptionHandler(WebSocketException.class)
+    @SendToUser(destinations = "/queue/errors")
+    public WebSocketErrorResponse handleWebSocketAuthError(WebSocketException exception) {
+        WebSocketErrorResponse webSocketErrorResponse = WebSocketErrorResponse.of(
+                exception.getErrorCode().getCode(),
+                exception.getErrorDescription()
+        );
+
+        // 예외 발생 로그 기록
+        log.error("{}", webSocketErrorResponse);
+
+        return webSocketErrorResponse;
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/jwt/JwtProvider.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/jwt/JwtProvider.java
@@ -1,0 +1,52 @@
+package com.wootecam.festivals.global.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * JWT 토큰을 관리하는 클래스.
+ * <p>
+ * - 최신 io.jsonwebtoken 라이브러리를 사용하여 JWT 생성 및 검증 기능을 제공한다. - 서명 검증을 `verifyWith()` 메서드를 통해 처리.
+ * </p>
+ *
+ * @author 김현준
+ */
+@Slf4j
+@Component
+public class JwtProvider {
+
+    private static final long ACCESS_TOKEN_VALIDITY = 60 * 60 * 1000L; // 1시간
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * JWT 액세스 토큰 생성.
+     *
+     * @param memberId 사용자 ID
+     * @return JWT 액세스 토큰
+     */
+    public String generateToken(Long memberId) {
+        return Jwts.builder()
+                .subject(String.valueOf(memberId))
+                .issuedAt(new Date())
+                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_VALIDITY))
+                .signWith(key)
+                .compact();
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/jwt/JwtProvider.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/jwt/JwtProvider.java
@@ -5,6 +5,7 @@ import com.wootecam.festivals.global.exception.WebSocketException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
@@ -28,12 +29,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtProvider {
 
-    private static final long ACCESS_TOKEN_VALIDITY = 60 * 60 * 1000L; // 1시간
+    public static final long ACCESS_TOKEN_VALIDITY = 5 * 60 * 1000L; // 5분
 
     @Value("${jwt.secret}")
     private String secretKey;
 
     private SecretKey key;
+
 
     @PostConstruct
     public void init() {
@@ -41,18 +43,20 @@ public class JwtProvider {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
+
     /**
-     * JWT 액세스 토큰 생성.
+     * JWT 액세스 토큰 생성 (유효시간 설정 가능)
      *
-     * @param memberId 사용자 ID
+     * @param memberId       사용자 ID
+     * @param validityMillis 토큰 유효 시간 (밀리초 단위)
      * @return JWT 액세스 토큰
      */
-    public String generateToken(Long memberId) {
+    public String generateToken(Long memberId, long validityMillis) {
         return Jwts.builder()
                 .subject(String.valueOf(memberId))
                 .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_VALIDITY))
-                .signWith(key)
+                .expiration(new Date(System.currentTimeMillis() + validityMillis)) // 유효 시간 동적 설정
+                .signWith(this.key, SIG.HS256)
                 .compact();
     }
 

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/global/jwt/JwtProvider.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/global/jwt/JwtProvider.java
@@ -1,6 +1,12 @@
 package com.wootecam.festivals.global.jwt;
 
+import com.wootecam.festivals.global.auth.AuthErrorCode;
+import com.wootecam.festivals.global.exception.WebSocketException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -49,4 +55,57 @@ public class JwtProvider {
                 .signWith(key)
                 .compact();
     }
+
+
+    /**
+     * JWT에서 사용자 ID를 추출하고 검증하는 메서드.
+     *
+     * <p>
+     * - JWT 서명을 검증하고, 유효한 경우 사용자 ID를 반환한다. - `verifyWith(key)`를 사용하여 서버에서 발급한 JWT인지 검증한다. - `claims.getSubject()`에서 사용자
+     * ID를 추출하여 반환한다. - JWT가 만료되었거나, 올바르지 않은 경우 예외를 발생시킨다.
+     * </p>
+     *
+     * @param token 검증할 JWT 토큰
+     * @return 사용자 ID (Long)
+     * @throws WebSocketException JWT가 유효하지 않거나 인증 실패 시 예외 발생
+     */
+    public Long getMemberIdFromToken(String token) {
+        Claims claims = extractClaimsFromToken(token);
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    /**
+     * JWT에서 Claims(페이로드)를 추출하고 서명을 검증하는 메서드.
+     *
+     * <p>
+     * - JWT의 서명을 검증하고, 유효한 경우 Claims 객체를 반환한다. - 만료되었거나, 올바르지 않은 JWT인 경우 예외를 발생시킨다.
+     * </p>
+     *
+     * @param token 검증할 JWT 토큰
+     * @return Claims 객체 (사용자 정보 포함)
+     * @throws WebSocketException JWT가 만료되었거나 서명이 올바르지 않은 경우 예외 발생
+     */
+    private Claims extractClaimsFromToken(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            log.warn("JWT 만료됨: {}", e.getMessage());
+            throw new WebSocketException(AuthErrorCode.UNAUTHORIZED, "토큰이 만료되었습니다.");
+        } catch (UnsupportedJwtException e) {
+            log.warn("지원되지 않는 JWT 형식: {}", e.getMessage());
+            throw new WebSocketException(AuthErrorCode.UNAUTHORIZED, "지원되지 않는 JWT 형식입니다.");
+        } catch (MalformedJwtException e) {
+            log.warn("잘못된 JWT 구조: {}", e.getMessage());
+            throw new WebSocketException(AuthErrorCode.UNAUTHORIZED, "JWT 구조가 올바르지 않습니다.");
+        } catch (IllegalArgumentException e) {
+            log.warn("JWT 처리 중 오류 발생: {}", e.getMessage());
+            throw new WebSocketException(AuthErrorCode.UNAUTHORIZED, "JWT 처리 중 오류가 발생했습니다.");
+        }
+    }
+
 }

--- a/backend/queue-server/src/main/resources/application.yml
+++ b/backend/queue-server/src/main/resources/application.yml
@@ -9,6 +9,8 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       password: ${REDIS_PASSWORD}
+jwt:
+  secret: ${JWT_SECRET_KEY}
 
 wait:
   queue:
@@ -25,6 +27,9 @@ spring:
       port: 6379
       password: ""
 
+jwt:
+  secret: "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"
+
 server:
   port: 8081
 ---
@@ -38,6 +43,9 @@ spring:
       host: redis
       port: 6379
       password: ""
+
+jwt:
+  secret: "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"
 ---
 spring:
   config:

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/WebSocketAuthArgumentResolverTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/WebSocketAuthArgumentResolverTest.java
@@ -1,0 +1,107 @@
+package com.wootecam.festivals.global.auth;
+
+import static com.wootecam.festivals.global.jwt.JwtProvider.ACCESS_TOKEN_VALIDITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.wootecam.festivals.global.exception.WebSocketException;
+import com.wootecam.festivals.global.jwt.JwtProvider;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+@DisplayName("WebSocketAuthArgumentResolver 테스트")
+class WebSocketAuthArgumentResolverTest extends SpringBootTestConfig {
+
+    @Autowired
+    private WebSocketAuthArgumentResolver resolver;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private MethodParameter parameter;
+
+    @Test
+    @DisplayName("JWT가 포함된 Authorization 헤더가 있으면 사용자 ID를 반환한다.")
+    void resolveArgument_validJwt_returnsUserId() throws Exception {
+        // Given
+        Long memberId = 123L;
+        String validToken = jwtProvider.generateToken(memberId, ACCESS_TOKEN_VALIDITY); // 정상적인 JWT 생성
+
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+        accessor.setNativeHeader("Authorization", "Bearer " + validToken);
+        Message<byte[]> message = MessageBuilder.withPayload(new byte[0])
+                .setHeaders(accessor)
+                .build();
+
+        // When
+        Object resolvedId = resolver.resolveArgument(parameter, message);
+
+        // Then
+        assertThat(resolvedId).isEqualTo(memberId);
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 예외가 발생한다.")
+    void resolveArgument_noAuthHeader_throwsException() {
+        // Given
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+        Message<byte[]> message = MessageBuilder.withPayload(new byte[0])
+                .setHeaders(accessor)
+                .build();
+
+        // When & Then
+        assertThrows(WebSocketException.class, () -> resolver.resolveArgument(parameter, message));
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 'Bearer '로 시작하지 않으면 예외가 발생한다.")
+    void resolveArgument_invalidAuthHeader_throwsException() {
+        // Given
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+        accessor.setNativeHeader("Authorization", "InvalidTokenFormat");
+        Message<byte[]> message = MessageBuilder.withPayload(new byte[0])
+                .setHeaders(accessor)
+                .build();
+
+        // When & Then
+        assertThrows(WebSocketException.class, () -> resolver.resolveArgument(parameter, message));
+    }
+
+    @Test
+    @DisplayName("만료된 JWT가 포함되었을 때 예외가 발생한다.")
+    void resolveArgument_expiredJwt_throwsException() {
+        // Given
+        Long memberId = 123L;
+        String expiredToken = createExpiredToken(memberId); // 만료된 JWT 생성
+
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+        accessor.setNativeHeader("Authorization", "Bearer " + expiredToken);
+        Message<byte[]> message = MessageBuilder.withPayload(new byte[0])
+                .setHeaders(accessor)
+                .build();
+
+        // When & Then
+        assertThrows(WebSocketException.class, () -> resolver.resolveArgument(parameter, message));
+    }
+
+    /**
+     * 1초 전에 만료된 JWT를 생성하는 메서드.
+     *
+     * @param memberId 사용자 ID
+     * @return 5초 전에 만료된 JWT
+     */
+    private String createExpiredToken(Long memberId) {
+        // 현재 시간보다 5초 전에 만료된 JWT 생성
+        return jwtProvider.generateToken(memberId, -1000L);
+    }
+
+}
+

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/WebSocketAuthArgumentResolverTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/WebSocketAuthArgumentResolverTest.java
@@ -3,6 +3,8 @@ package com.wootecam.festivals.global.auth;
 import static com.wootecam.festivals.global.jwt.JwtProvider.ACCESS_TOKEN_VALIDITY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.wootecam.festivals.global.exception.WebSocketException;
 import com.wootecam.festivals.global.jwt.JwtProvider;
@@ -96,12 +98,72 @@ class WebSocketAuthArgumentResolverTest extends SpringBootTestConfig {
      * 1초 전에 만료된 JWT를 생성하는 메서드.
      *
      * @param memberId 사용자 ID
-     * @return 5초 전에 만료된 JWT
+     * @return 1초 전에 만료된 JWT
      */
     private String createExpiredToken(Long memberId) {
-        // 현재 시간보다 5초 전에 만료된 JWT 생성
         return jwtProvider.generateToken(memberId, -1000L);
     }
 
-}
+    // --------------- supportsParameter() 메서드 테스트 ---------------
 
+    @Test
+    @DisplayName("@AuthUser 어노테이션이 있고 Long 타입이면 true를 반환한다.")
+    void supportsParameter_withAuthUserAndLongType_returnsTrue() {
+        // Given
+        MethodParameter mockParameter = mock(MethodParameter.class);
+        when(mockParameter.hasParameterAnnotation(AuthUser.class)).thenReturn(true);
+        when(mockParameter.getParameterType()).thenReturn((Class) Long.class);
+
+        // When
+        boolean result = resolver.supportsParameter(mockParameter);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("@AuthUser 어노테이션이 없으면 false를 반환한다.")
+    void supportsParameter_withoutAuthUserAnnotation_returnsFalse() {
+        // Given
+        MethodParameter mockParameter = mock(MethodParameter.class);
+        when(mockParameter.hasParameterAnnotation(AuthUser.class)).thenReturn(false);
+        when(mockParameter.getParameterType()).thenReturn((Class) Long.class);
+
+        // When
+        boolean result = resolver.supportsParameter(mockParameter);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("Long 타입이 아니면 false를 반환한다.")
+    void supportsParameter_withNonLongType_returnsFalse() {
+        // Given
+        MethodParameter mockParameter = mock(MethodParameter.class);
+        when(mockParameter.hasParameterAnnotation(AuthUser.class)).thenReturn(true);
+        when(mockParameter.getParameterType()).thenReturn((Class) String.class);
+
+        // When
+        boolean result = resolver.supportsParameter(mockParameter);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("Long 타입이고 @AuthUser가 있으면 true를 반환한다.")
+    void supportsParameter_withLongTypeAndAuthUser_returnsTrue() {
+        // Given
+        MethodParameter mockParameter = mock(MethodParameter.class);
+        when(mockParameter.hasParameterAnnotation(AuthUser.class)).thenReturn(true);
+        when(mockParameter.getParameterType()).thenReturn((Class) Long.class);
+
+        // When
+        boolean result = resolver.supportsParameter(mockParameter);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+}

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptorTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptorTest.java
@@ -1,0 +1,100 @@
+package com.wootecam.festivals.global.auth.interceptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wootecam.festivals.global.auth.Authentication;
+import com.wootecam.festivals.global.utils.AuthenticationUtils;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@DisplayName("WebSocketAuthInterceptor 클래스")
+class WebSocketAuthInterceptorTest extends SpringBootTestConfig {
+
+    @Autowired
+    private WebSocketAuthInterceptor interceptor;
+
+    private MockHttpSession session;
+
+    @BeforeEach
+    void setUp() {
+        session = new MockHttpSession();
+    }
+
+    @Nested
+    @DisplayName("beforeHandshake 메소드는")
+    class Describe_beforeHandshake {
+
+        @Test
+        @DisplayName("인증된 사용자는 WebSocket 연결을 허용하고 JWT가 Set-Cookie로 반환된다.")
+        void it_allows_authenticated_user() throws Exception {
+            // Given: 인증 정보를 세션에 추가
+            Authentication authentication = new Authentication(1L);
+            session.setAttribute(AuthenticationUtils.AUTHENTICATION, authentication);
+
+            // Mock HTTP 요청 및 응답 생성
+            MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+            servletRequest.setSession(session);
+            MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+
+            ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+            ServletServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
+            Map<String, Object> attributes = new HashMap<>();
+
+            // When: WebSocket 핸드셰이크 실행
+            boolean result = interceptor.beforeHandshake(request, response, null, attributes);
+
+            // Then: 인증이 성공하여 핸드셰이크가 허용됨
+            assertThat(result).isTrue();
+
+            // Set-Cookie 헤더에 JWT가 포함되었는지 확인
+            assertThat(response.getHeaders()).containsKey("Set-Cookie");
+
+            // Set-Cookie 헤더 값 확인 (JWT 토큰이 포함되었는지 검증)
+            List<String> setCookieHeaders = response.getHeaders().get("Set-Cookie");
+            assertThat(setCookieHeaders).isNotEmpty();
+
+            // JWT 토큰이 있는지 확인 (WebSocket-Token= 으로 시작하는 값이 있는지 체크)
+            boolean hasJwtToken = setCookieHeaders.stream()
+                    .anyMatch(cookie -> cookie.startsWith("WebSocket-Token="));
+
+            assertThat(hasJwtToken).isTrue();
+        }
+
+
+        @Test
+        @DisplayName("인증되지 않은 사용자는 WebSocket 연결이 거부된다.")
+        void it_denies_unauthenticated_user() throws Exception {
+            // Given
+            MockHttpServletRequest servletRequest = new MockHttpServletRequest();
+            servletRequest.setSession(session);
+            MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+            RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(servletRequest));
+
+            ServletServerHttpRequest request = new ServletServerHttpRequest(servletRequest);
+            ServletServerHttpResponse response = new ServletServerHttpResponse(servletResponse);
+            Map<String, Object> attributes = new HashMap<>();
+
+            // When
+            boolean result = interceptor.beforeHandshake(request, response, null, attributes);
+
+            // Then
+            assertThat(result).isFalse();
+            assertThat(response.getServletResponse().getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        }
+    }
+}

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptorTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptorTest.java
@@ -1,6 +1,7 @@
 package com.wootecam.festivals.global.auth.interceptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.wootecam.festivals.global.auth.Authentication;
 import com.wootecam.festivals.global.jwt.JwtProvider;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -73,7 +75,6 @@ class WebSocketAuthInterceptorTest extends SpringBootTestConfig {
             assertThat(authHeaders).isNotEmpty();
         }
 
-
         @Test
         @DisplayName("인증되지 않은 사용자는 WebSocket 연결이 거부된다.")
         void it_denies_unauthenticated_user() throws Exception {
@@ -89,6 +90,22 @@ class WebSocketAuthInterceptorTest extends SpringBootTestConfig {
 
             // When
             boolean result = interceptor.beforeHandshake(request, response, null, attributes);
+
+            // Then
+            assertThat(result).isFalse();
+            assertThat(response.getServletResponse().getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+        }
+
+        @Test
+        @DisplayName("request가 ServletServerHttpRequest가 아닐 때 WebSocket 연결이 거부된다.")
+        void it_denies_non_http_request() throws Exception {
+            // Given: ServerHttpRequest의 Mock 객체 생성
+            ServerHttpRequest nonHttpRequest = mock(ServerHttpRequest.class); // Mock 객체 사용
+            ServletServerHttpResponse response = new ServletServerHttpResponse(new MockHttpServletResponse());
+            Map<String, Object> attributes = new HashMap<>();
+
+            // When
+            boolean result = interceptor.beforeHandshake(nonHttpRequest, response, null, attributes);
 
             // Then
             assertThat(result).isFalse();

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptorTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/global/auth/interceptor/WebSocketAuthInterceptorTest.java
@@ -3,6 +3,7 @@ package com.wootecam.festivals.global.auth.interceptor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.wootecam.festivals.global.auth.Authentication;
+import com.wootecam.festivals.global.jwt.JwtProvider;
 import com.wootecam.festivals.global.utils.AuthenticationUtils;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.util.HashMap;
@@ -28,6 +29,9 @@ class WebSocketAuthInterceptorTest extends SpringBootTestConfig {
     @Autowired
     private WebSocketAuthInterceptor interceptor;
 
+    @Autowired
+    private JwtProvider jwtProvider;
+
     private MockHttpSession session;
 
     @BeforeEach
@@ -40,7 +44,7 @@ class WebSocketAuthInterceptorTest extends SpringBootTestConfig {
     class Describe_beforeHandshake {
 
         @Test
-        @DisplayName("인증된 사용자는 WebSocket 연결을 허용하고 JWT가 Set-Cookie로 반환된다.")
+        @DisplayName("인증된 사용자는 WebSocket 연결을 허용하고 JWT가 Authorization 헤더에 반환된다.")
         void it_allows_authenticated_user() throws Exception {
             // Given: 인증 정보를 세션에 추가
             Authentication authentication = new Authentication(1L);
@@ -61,18 +65,12 @@ class WebSocketAuthInterceptorTest extends SpringBootTestConfig {
             // Then: 인증이 성공하여 핸드셰이크가 허용됨
             assertThat(result).isTrue();
 
-            // Set-Cookie 헤더에 JWT가 포함되었는지 확인
-            assertThat(response.getHeaders()).containsKey("Set-Cookie");
+            // Authorization 헤더에 JWT가 포함되었는지 확인
+            assertThat(response.getHeaders()).containsKey("Authorization");
 
-            // Set-Cookie 헤더 값 확인 (JWT 토큰이 포함되었는지 검증)
-            List<String> setCookieHeaders = response.getHeaders().get("Set-Cookie");
-            assertThat(setCookieHeaders).isNotEmpty();
-
-            // JWT 토큰이 있는지 확인 (WebSocket-Token= 으로 시작하는 값이 있는지 체크)
-            boolean hasJwtToken = setCookieHeaders.stream()
-                    .anyMatch(cookie -> cookie.startsWith("WebSocket-Token="));
-
-            assertThat(hasJwtToken).isTrue();
+            // Authorization 헤더 값 확인 (JWT 토큰이 포함되었는지 검증)
+            List<String> authHeaders = response.getHeaders().get("Authorization");
+            assertThat(authHeaders).isNotEmpty();
         }
 
 

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/global/jwt/JwtProviderTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/global/jwt/JwtProviderTest.java
@@ -1,0 +1,77 @@
+package com.wootecam.festivals.global.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.wootecam.festivals.global.auth.AuthErrorCode;
+import com.wootecam.festivals.global.exception.WebSocketException;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class JwtProviderTest extends SpringBootTestConfig {
+
+    public static final long ACCESS_TOKEN_VALIDITY = JwtProvider.ACCESS_TOKEN_VALIDITY; // 5분
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("JWT를 정상적으로 생성할 수 있다.")
+    void it_generates_valid_jwt() {
+        // Given
+        Long memberId = 1L;
+
+        // When
+        String token = jwtProvider.generateToken(memberId, ACCESS_TOKEN_VALIDITY);
+
+        // Then
+        assertThat(token).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("유효한 JWT에서 사용자 ID를 정상적으로 추출할 수 있다.")
+    void it_extracts_member_id_from_valid_token() {
+        // Given
+        Long memberId = 1L;
+        String token = jwtProvider.generateToken(memberId, ACCESS_TOKEN_VALIDITY);
+
+        // When
+        Long extractedMemberId = jwtProvider.getMemberIdFromToken(token);
+
+        // Then
+        assertThat(extractedMemberId).isEqualTo(memberId);
+    }
+
+    @Test
+    @DisplayName("만료된 JWT를 검증할 때 예외가 발생해야 한다.")
+    void it_throws_exception_when_token_is_expired() {
+        // Given: 즉시 만료된 JWT 생성
+        Long memberId = 1L;
+        String expiredToken = jwtProvider.generateToken(memberId, -1000L);
+
+        // When & Then
+        WebSocketException exception = assertThrows(WebSocketException.class, () -> {
+            jwtProvider.getMemberIdFromToken(expiredToken);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.UNAUTHORIZED);
+        assertThat(exception.getMessage()).contains("토큰이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("잘못된 JWT를 검증할 때 예외가 발생해야 한다.")
+    void it_throws_exception_when_token_is_invalid() {
+        // Given
+        String invalidToken = "invalid.jwt.token";
+
+        // When & Then
+        WebSocketException exception = assertThrows(WebSocketException.class, () -> {
+            jwtProvider.getMemberIdFromToken(invalidToken);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.UNAUTHORIZED);
+        assertThat(exception.getMessage()).contains("JWT 구조가 올바르지 않습니다.");
+    }
+}

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/global/jwt/JwtProviderTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/global/jwt/JwtProviderTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.wootecam.festivals.global.auth.AuthErrorCode;
 import com.wootecam.festivals.global.exception.WebSocketException;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
+import io.jsonwebtoken.Jwts;
+import java.util.Date;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,17 +63,65 @@ class JwtProviderTest extends SpringBootTestConfig {
     }
 
     @Test
-    @DisplayName("잘못된 JWT를 검증할 때 예외가 발생해야 한다.")
-    void it_throws_exception_when_token_is_invalid() {
-        // Given
-        String invalidToken = "invalid.jwt.token";
+    @DisplayName("지원되지 않는 JWT 형식을 검증할 때 예외가 발생해야 한다.")
+    void it_throws_exception_when_token_is_unsupported() {
+        // Given: 임의의 잘못된 JWT 구조
+        String unsupportedToken = Jwts.builder()
+                .subject("1")
+                .issuedAt(new Date())
+                .compact(); // 서명이 없는 JWT
 
         // When & Then
         WebSocketException exception = assertThrows(WebSocketException.class, () -> {
-            jwtProvider.getMemberIdFromToken(invalidToken);
+            jwtProvider.getMemberIdFromToken(unsupportedToken);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.UNAUTHORIZED);
+        assertThat(exception.getMessage()).contains("지원되지 않는 JWT 형식입니다.");
+    }
+
+    @Test
+    @DisplayName("잘못된 구조의 JWT를 검증할 때 예외가 발생해야 한다.")
+    void it_throws_exception_when_token_is_malformed() {
+        // Given
+        String malformedToken = "malformed.jwt.token";
+
+        // When & Then
+        WebSocketException exception = assertThrows(WebSocketException.class, () -> {
+            jwtProvider.getMemberIdFromToken(malformedToken);
         });
 
         assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.UNAUTHORIZED);
         assertThat(exception.getMessage()).contains("JWT 구조가 올바르지 않습니다.");
+    }
+
+    @Test
+    @DisplayName("비어있는 JWT를 검증할 때 예외가 발생해야 한다.")
+    void it_throws_exception_when_token_is_empty() {
+        // Given
+        String emptyToken = "";
+
+        // When & Then
+        WebSocketException exception = assertThrows(WebSocketException.class, () -> {
+            jwtProvider.getMemberIdFromToken(emptyToken);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.UNAUTHORIZED);
+        assertThat(exception.getMessage()).contains("JWT 처리 중 오류가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("null JWT를 검증할 때 예외가 발생해야 한다.")
+    void it_throws_exception_when_token_is_null() {
+        // Given
+        String nullToken = null;
+
+        // When & Then
+        WebSocketException exception = assertThrows(WebSocketException.class, () -> {
+            jwtProvider.getMemberIdFromToken(nullToken);
+        });
+
+        assertThat(exception.getErrorCode()).isEqualTo(AuthErrorCode.UNAUTHORIZED);
+        assertThat(exception.getMessage()).contains("JWT 처리 중 오류가 발생했습니다.");
     }
 }

--- a/backend/queue-server/src/test/resources/application.yml
+++ b/backend/queue-server/src/test/resources/application.yml
@@ -8,3 +8,6 @@ spring:
 wait:
   queue:
     pass-chunk-size: 4
+
+jwt:
+  secret: "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"


### PR DESCRIPTION
## 📄 작업 설명
웹소켓을 사용하기 위한 config를 설정했어요.
Interceptor로 웹소켓 업그레이드를 위한 핸드셰이크 과정 중에 세션을 jwt 토큰으로 바꾸어서 웹소켓 이용 시 인증하도록 구현했어요.
ArgumentResolver를 이용해 jwt를 바꾸는 과정을 거쳐서 @AuthUser 라는 어노테이션을 붙이면 자동으로 memberId로 바뀌어요 !
또한 ExceptorHandler도 웹소켓 전용 handler가 따로 있어서 구현했습니다 !

하트비트는 10초로 설정해서 10초마다 사용자 연결 체크를 하고, 메시지 브로커 url인 /topic, /queue는 각각 1:N, 1:1 연결을 나타내는 관행적 표현이라고 합니다. 참고해서 /topic이 붙은 구독은 1:N이고 /queue 개인사용자 1:1이라고 생각해주세요.

그 외의 사항은 첨부한 문서를 보시면 될 거 같아요 !

## 🚨 관련 이슈
closes #22 

## 🌈 작업 상황
- 인증 관련 jwt 구현 및 argumentResolver 구현
- 웹소켓 config 구현

## 📌 기타
참고문서
https://docs.spring.io/spring-framework/docs/4.3.12.RELEASE/spring-framework-reference/html/websocket.html?utm_source=chatgpt.com
