### PR TITLE
Feat#27: Spring Quartz 로직 수정

### DIFF
--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalScheduleJob.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalScheduleJob.java
@@ -5,6 +5,7 @@ import com.wootecam.festivals.global.exception.GlobalErrorCode;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@DisallowConcurrentExecution
 public class FestivalScheduleJob implements Job {
 
     private final FestivalStatusUpdateService festivalStatusUpdateService;

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
@@ -45,7 +45,6 @@ public class FestivalSchedulerService {
         log.debug("시작 시간 : {}", festival.getStartTime());
         log.debug("종료 시간 : {}", festival.getEndTime());
 
-
         scheduleStartTimeUpdate(findFestival);
         scheduleEndTimeUpdate(findFestival);
     }
@@ -95,7 +94,7 @@ public class FestivalSchedulerService {
                     .withIdentity(triggerKey, "festivalGroup")
                     .startAt(java.sql.Timestamp.valueOf(triggerTime))
                     .withPriority(priority)
-                    .withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionIgnoreMisfires())
+                    .withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionFireNow())
                     .build();
 
             if (scheduler.checkExists(jobDetail.getKey())) {

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleJob.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleJob.java
@@ -10,6 +10,7 @@ import com.wootecam.festivals.global.exception.GlobalErrorCode;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.quartz.DisallowConcurrentExecution;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@DisallowConcurrentExecution
 public class TicketScheduleJob implements Job {
 
     private final TicketInfoRedisRepository ticketInfoRedisRepository;

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleService.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleService.java
@@ -52,7 +52,7 @@ public class TicketScheduleService {
             Trigger trigger = TriggerBuilder.newTrigger()
                     .withIdentity(triggerKey, "ticketGroup")
                     .startAt(java.sql.Timestamp.valueOf(scheduleTime))
-                    .withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionIgnoreMisfires())
+                    .withSchedule(SimpleScheduleBuilder.simpleSchedule().withMisfireHandlingInstructionFireNow())
                     .build();
 
             if (scheduler.checkExists(jobDetail.getKey())) {

--- a/backend/schedule-server/src/main/resources/application.yml
+++ b/backend/schedule-server/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
           useProperties: false
           dataSource: schedule
           isClustered: true
-          misfireThreshold: 30000
+          misfireThreshold: 10000
           clusterCheckinInterval: 10000
           tablePrefix: QRTZ_ # Quartz 테이블 이름 접두사
         dataSource:

--- a/backend/schedule-server/src/test/resources/application.yml
+++ b/backend/schedule-server/src/test/resources/application.yml
@@ -30,7 +30,7 @@ spring:
           useProperties: false
           dataSource: schedule
           isClustered: true
-          misfireThreshold: 30000
+          misfireThreshold: 1000
           clusterCheckinInterval: 10000
           tablePrefix: QRTZ_ # Quartz 테이블 이름 접두사
         dataSource:


### PR DESCRIPTION
## 📄 작업 설명
Quartz 스케줄러의 내부 쓰레드 풀 내에서의 중복 실행 문제를 방지하고, 미스파이어(Misfire) 정책을 수정하여 테스트 환경에서도 안정적으로 동작하도록 개선하였습니다.

- `@DisallowConcurrentExecution` 어노테이션을 적용하여 동일한 Job이 동시에 실행되지 않도록 제한하였습니다.
- 기존 미스파이어 정책으로 인해 트리거가 일정 시간 이후 실행되지 않는 문제가 있었으며, 이를 방지하기 위해 미스파이어 발생 시 즉시 실행(`MisfireInstructionFireNow`)하는 정책을 적용하였습니다.
- 테스트 환경에서 `misfireThreshold` 값을 1000ms로 조정하여 빠르게 미스파이어를 감지하고, 테스트가 실패하지 않도록 조정하였습니다.
- 테스트 환경에서 `FireNow()` 실행 시 미스파이어가 감지되지 않아 Job이 실행되지 않는 문제가 있었으며, `misfireThreshold` 값을 짧게 설정하여 해결하였습니다.

## 🚨 관련 이슈
closes #27 

## 🌈 작업 상황
- `@DisallowConcurrentExecution` 적용하여 동일한 Job의 중복 실행 방지
- `MisfireInstructionFireNow` 정책을 적용하여 미스파이어 발생 시 즉시 실행되도록 변경
- 테스트 환경에서 `misfireThreshold` 값을 1000ms로 조정하여 빠른 감지를 유도
- 테스트 환경에서 `FireNow()` 실행 시 미스파이어 감지 실패로 Job이 실행되지 않는 문제 해결

## 📌 기타
