### PR TITLE
Fix#29: Quartz Job 비정상 종료 시 자동 복구 설정 추가

### DIFF
--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
@@ -86,6 +86,7 @@ public class FestivalSchedulerService {
                     .usingJobData("festivalId", festivalId)
                     .usingJobData("festivalStatus", status.name())
                     .storeDurably(false)
+                    .requestRecovery(true)
                     .build();
 
             int priority = eventType.equals("시작") ? 100 : 5;

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleService.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleService.java
@@ -45,6 +45,7 @@ public class TicketScheduleService {
                     .withIdentity(jobKey, "ticketGroup")
                     .usingJobData("ticket", ticketToJson)
                     .storeDurably(false)
+                    .requestRecovery(true)
                     .build();
 
             LocalDateTime scheduleTime = ticket.startSaleTime().minusMinutes(10);


### PR DESCRIPTION
📄 작업 설명
Quartz 스케줄러에서 비정상 종료된 Job이 자동으로 복구될 수 있도록 requestsRecovery(true) 설정을 추가하였습니다.
이를 통해 서버가 갑작스럽게 종료되거나 장애가 발생한 경우에도 실행되지 않은 Job이 복구되어 정상적으로 실행될 수 있습니다.

🚨 관련 이슈
closes #29

🌈 작업 상황
JobDetail 생성 시 requestsRecovery(true) 설정 추가하여 복구 가능하도록 변경
Quartz의 QRTZ_TRIGGERS 테이블에서 복구 대상 Job을 식별하도록 설정
서버 재시작 시 미처리된 Job이 자동 실행되도록 Quartz 스케줄러 복구 로직 검증

## 📌 기타
