### PR TITLE
Feat#25: 대기열 관리 모듈 구현

### DIFF
--- a/.github/workflows/jacoco-rule.yml
+++ b/.github/workflows/jacoco-rule.yml
@@ -28,7 +28,6 @@ jobs:
           echo "Checking api-server Jacoco Test Report:"
           if [ -f backend/api-server/build/reports/jacoco/test/jacocoTestReport.xml ]; then
             echo "api-server Jacoco Test Report exists"
-            ls -l backend/api-server/build/reports/jacoco/test/
           else
             echo "api-server Jacoco Test Report does not exist"
             exit 1
@@ -37,9 +36,32 @@ jobs:
           echo "Checking queue-server Jacoco Test Report:"
           if [ -f backend/queue-server/build/reports/jacoco/test/jacocoTestReport.xml ]; then
             echo "queue-server Jacoco Test Report exists"
-            ls -l backend/queue-server/build/reports/jacoco/test/
           else
             echo "queue-server Jacoco Test Report does not exist"
+            exit 1
+          fi
+
+          echo "Checking payment-server Jacoco Test Report:"
+          if [ -f backend/payment-server/build/reports/jacoco/test/jacocoTestReport.xml ]; then
+            echo "payment-server Jacoco Test Report exists"
+          else
+            echo "payment-server Jacoco Test Report does not exist"
+            exit 1
+          fi
+
+          echo "Checking schedule-server Jacoco Test Report:"
+          if [ -f backend/schedule-server/build/reports/jacoco/test/jacocoTestReport.xml ]; then
+            echo "schedule-server Jacoco Test Report exists"
+          else
+            echo "schedule-server Jacoco Test Report does not exist"
+            exit 1
+          fi
+          
+          echo "Checking queue-manager-server Jacoco Test Report:"
+          if [ -f backend/queue-manager-server/build/reports/jacoco/test/jacocoTestReport.xml ]; then
+            echo "queue-manager-server Jacoco Test Report exists"
+          else
+            echo "queue-manager-server Jacoco Test Report does not exist"
             exit 1
           fi
 
@@ -64,7 +86,10 @@ jobs:
         with:
           paths: |
             ${{ github.workspace }}/backend/api-server/build/reports/jacoco/test/jacocoTestReport.xml,
-            ${{ github.workspace }}/backend/queue-server/build/reports/jacoco/test/jacocoTestReport.xml
+            ${{ github.workspace }}/backend/queue-server/build/reports/jacoco/test/jacocoTestReport.xml,
+            ${{ github.workspace }}/backend/schedule-server/build/reports/jacoco/test/jacocoTestReport.xml,
+            ${{ github.workspace }}/backend/payment-server/build/reports/jacoco/test/jacocoTestReport.xml,
+            ${{ github.workspace }}/backend/queue-manager-server/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 80
           min-coverage-changed-files: 80

--- a/backend/api-server/src/main/java/com/wootecam/festivals/FestivalsApplication.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/FestivalsApplication.java
@@ -5,14 +5,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableConfigurationProperties(CloudConfiguration.class)
 @EnableAsync
 public class FestivalsApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(FestivalsApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(FestivalsApplication.class, args);
+    }
 }

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
@@ -2,7 +2,6 @@ package com.wootecam.festivals.domain.purchase.service;
 
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
-import com.wootecam.festivals.domain.payment.entity.Payment;
 import com.wootecam.festivals.domain.purchase.dto.PurchasableResponse;
 import com.wootecam.festivals.domain.purchase.dto.PurchasePreviewInfoResponse;
 import com.wootecam.festivals.domain.purchase.exception.PurchaseErrorCode;
@@ -15,7 +14,6 @@ import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockRepository;
 import com.wootecam.festivals.global.auth.purchase.PurchaseSession;
 import com.wootecam.festivals.global.exception.type.ApiException;
-import com.wootecam.festivals.global.utils.TimeProvider;
 import com.wootecam.festivals.global.utils.UuidProvider;
 import jakarta.persistence.PersistenceException;
 import java.sql.SQLIntegrityConstraintViolationException;
@@ -24,7 +22,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,17 +33,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PurchaseService {
 
-    @Value("${purchase.session.ttl:5}")
-    private Long purchaseSessionTtl;
-
     private final PurchaseRepository purchaseRepository;
     private final TicketStockRepository ticketStockRepository;
     private final MemberRepository memberRepository;
     private final TicketRepository ticketRepository;
-    private final TimeProvider timeProvider;
     private final UuidProvider uuidProvider;
-    private final RedisTemplate<String, String> redisTemplate;
     private final PurchaseSessionRedisRepository purchaseSessionRedisRepository;
+    @Value("${purchase.session.ttl:5}")
+    private Long purchaseSessionTtl;
 
     /**
      * 티켓 구매 권한이 유효한지 확인합니다.

--- a/backend/api-server/src/main/java/com/wootecam/festivals/global/config/CloudConfiguration.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/global/config/CloudConfiguration.java
@@ -1,9 +1,7 @@
 package com.wootecam.festivals.global.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
 @ConfigurationProperties(prefix = "cloud")
 public class CloudConfiguration {
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -122,13 +122,25 @@ subprojects {
         afterEvaluate {
             classDirectories.setFrom(files(classDirectories.files.collect {
                 fileTree(dir: it, exclude: [
+                        //spring boot application class
                         '**/QueueApplication.class',
-                        '**/FestivalsApplication.class', // exclude main class
+                        '**/FestivalsApplication.class',
+                        '**/ScheduleServerApplication.class',
+                        '**/PaymentServerApplication.class',
+                        '**/QueueManagerApplication.class',
+
                         '**/global/audit/**', // exclude audit package
-                        '**/dto/**', // exclude dto package
-                        '**/global/exception/**', // exclude exception package
                         '**/global/api/**', // exclude api package
+                        '**/global/auth/**', // exclude auth package
+                        '**/global/constants/**', // exclude constants package
                         '**/global/config/**', // exclude config package
+                        '**/global/docs/**', // exclude docs package
+                        '**/global/log/**',
+                        "**/config/**",  // exclude config package
+
+                        '**/dto/**',
+                        '**/utils/**',
+                        '**/exception/**',
                 ])
             }))
         }
@@ -160,7 +172,6 @@ subprojects {
                         '**/exception/**',
 
                         '**/domain/purchase/repository/**',
-                        "**/service/TicketService.class'", // 테스트 버그로 인해 임시 제외,
                         "**/*Producer.*" // exclude Producer class
                 ])
             }))

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -146,21 +146,22 @@ subprojects {
                         '**/PaymentServerApplication.class',
                         '**/QueueManagerApplication.class',
 
-                        '**/dto/**', // exclude dto package
+
                         '**/global/audit/**', // exclude audit package
                         '**/global/api/**', // exclude api package
                         '**/global/auth/**', // exclude auth package
                         '**/global/constants/**', // exclude constants package
                         '**/global/config/**', // exclude config package
                         '**/global/docs/**', // exclude docs package
-                        '**/global/exception/**', // exclude exception package
-                        '**/global/utils/**', // exclude utils package
-                        '**/utils/**', // exclude utils package
-                        '**/domain/purchase/exception/**',
-                        '**/domain/purchase/repository/**',
-                        '**/global/log/**', // exclude utils package
-                        "**/service/TicketService.class'", // 테스트 버그로 인해 임시 제외,
+                        '**/global/log/**',
                         "**/config/**",  // exclude config package
+
+                        '**/dto/**',
+                        '**/utils/**',
+                        '**/exception/**',
+
+                        '**/domain/purchase/repository/**',
+                        "**/service/TicketService.class'", // 테스트 버그로 인해 임시 제외,
                         "**/*Producer.*" // exclude Producer class
                 ])
             }))

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -139,10 +139,13 @@ subprojects {
         afterEvaluate {
             classDirectories.setFrom(files(classDirectories.files.collect {
                 fileTree(dir: it, exclude: [
+                        //spring boot application class
                         '**/QueueApplication.class',
                         '**/FestivalsApplication.class',
                         '**/ScheduleServerApplication.class',
                         '**/PaymentServerApplication.class',
+                        '**/QueueManagerApplication.class',
+
                         '**/dto/**', // exclude dto package
                         '**/global/audit/**', // exclude audit package
                         '**/global/api/**', // exclude api package
@@ -215,6 +218,12 @@ project(':queue-server') {
 }
 
 project('payment-server') {
+    dependencies {
+        implementation project(':core')
+    }
+}
+
+project('queue-manager-server') {
     dependencies {
         implementation project(':core')
     }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -161,6 +161,7 @@ subprojects {
                         '**/exception/**',
 
                         '**/domain/purchase/repository/**',
+                        '**/domain/queue/repository/**',
                         "**/service/TicketService.class'", // 테스트 버그로 인해 임시 제외,
                         "**/*Producer.*" // exclude Producer class
                 ])

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -146,7 +146,6 @@ subprojects {
                         '**/PaymentServerApplication.class',
                         '**/QueueManagerApplication.class',
 
-
                         '**/global/audit/**', // exclude audit package
                         '**/global/api/**', // exclude api package
                         '**/global/auth/**', // exclude auth package
@@ -161,7 +160,6 @@ subprojects {
                         '**/exception/**',
 
                         '**/domain/purchase/repository/**',
-                        '**/domain/queue/repository/**',
                         "**/service/TicketService.class'", // 테스트 버그로 인해 임시 제외,
                         "**/*Producer.*" // exclude Producer class
                 ])

--- a/backend/core/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketInfoWithId.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/domain/ticket/entity/TicketInfoWithId.java
@@ -1,0 +1,8 @@
+package com.wootecam.festivals.domain.ticket.entity;
+
+import java.time.LocalDateTime;
+
+public record TicketInfoWithId(Long ticketId,
+                               LocalDateTime startSaleTime,
+                               LocalDateTime endSaleTime) {
+}

--- a/backend/core/src/main/java/com/wootecam/festivals/domain/ticket/repository/RedisRepository.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/domain/ticket/repository/RedisRepository.java
@@ -8,8 +8,6 @@ public abstract class RedisRepository {
 
     public final String TICKETS_PREFIX = "tickets:";
     public final String TICKET_STOCK_COUNT_PREFIX = "ticketStocks:count";
-    public final String TICKET_INFO_START_SALE_TIME_PREFIX = "startSaleTime";
-    public final String TICKET_INFO_END_SALE_TIME_PREFIX = "endSaleTime";
 
     protected final RedisTemplate<String, String> redisTemplate;
 }

--- a/backend/core/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketInfoRedisRepository.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/domain/ticket/repository/TicketInfoRedisRepository.java
@@ -1,41 +1,101 @@
 package com.wootecam.festivals.domain.ticket.repository;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wootecam.festivals.domain.ticket.entity.TicketInfo;
+import com.wootecam.festivals.domain.ticket.entity.TicketInfoWithId;
+import com.wootecam.festivals.global.utils.TimeProvider;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
 /**
- *   티켓 정보를 관리하는 Repository
- *
- *   Hash 로 구현되어 있으며 티켓 메타 데이터를 관리
- *   key : tickets:{ticketId}
- *   hashKey : startSaleTime, endSaleTime
- *
- *   tickets:{ticketId}:startSaleTime 티켓 판매 시작 시각
- *   tickets:{ticketId}:endSaleTime 티켓 판매 종료 시각
+ * 티켓 정보를 관리하는 Repository
+ * <p> Hash 로 구현되어 있으며 티켓 메타 데이터를 관리 </p>
+ * <p> Hash Key: tickets_info
+ * <p> Field: ticket:{ticketId} </p>
+ * <p> Value: {@link TicketInfo} </p>
  */
 @Repository
+@Slf4j
 public class TicketInfoRedisRepository extends RedisRepository {
 
-    public TicketInfoRedisRepository(RedisTemplate<String, String> redisTemplate) {
+    public static final String TICKET_INFO_KEY = "ticket_info";
+
+    private final HashOperations<String, String, String> hashOperations;
+
+    private final TimeProvider timeProvider;
+    private final ObjectMapper mapper;
+
+    public TicketInfoRedisRepository(RedisTemplate<String, String> redisTemplate, TimeProvider timeProvider,
+                                     ObjectMapper mapper) {
         super(redisTemplate);
+        this.hashOperations = redisTemplate.opsForHash();
+        this.timeProvider = timeProvider;
+        this.mapper = mapper;
     }
 
     /**
-     *    티켓 정보를 가져오는 메소드
-     *    존재하지 않는 티켓이라면 null 반환
+     * <p> 티켓 정보를 가져오는 메소드 </p>
+     * <p> 존재하지 않는 티켓이라면 null 반환 </p>
      */
     public TicketInfo getTicketInfo(Long ticketId) {
-        String startSaleTime = (String) redisTemplate.opsForHash().get(TICKETS_PREFIX + ticketId, TICKET_INFO_START_SALE_TIME_PREFIX);
-        String endSaleTime = (String) redisTemplate.opsForHash().get(TICKETS_PREFIX + ticketId, TICKET_INFO_END_SALE_TIME_PREFIX);
-
-        if (startSaleTime == null || endSaleTime == null) {
+        String value = hashOperations.get(TICKET_INFO_KEY, formatField(ticketId));
+        if (value == null) {
             return null;
         }
 
-        return new TicketInfo(LocalDateTime.parse(startSaleTime), LocalDateTime.parse(endSaleTime));
+        TicketInfo ticketInfo = null;
+        try {
+            ticketInfo = mapper.readValue(value, TicketInfo.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+
+        return ticketInfo;
+    }
+
+    /**
+     * <p> 현재 판매 중인 티켓 정보를 가져오는 메소드 </p>
+     */
+    public List<TicketInfoWithId> getTicketsWithSaleStarted() {
+        LocalDateTime currentTime = timeProvider.getCurrentTime();
+
+        // Redis에서 모든 티켓 정보 조회
+        Map<String, String> entries = hashOperations.entries(TICKET_INFO_KEY);
+        if (entries.isEmpty()) {
+            return List.of();
+        }
+
+        return entries.entrySet().stream().map(entry -> {
+            try {
+                TicketInfo ticketInfo = mapper.readValue(entry.getValue(), TicketInfo.class);
+                return isTicketOnSale(ticketInfo, currentTime)
+                        ? createTicketInfoWithId(entry.getKey(), ticketInfo)
+                        : null;
+            } catch (JsonProcessingException e) {
+                log.error("Failed to deserialize ticket info for key: {}", entry.getKey(), e);
+                return null;
+            }
+        }).filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    private TicketInfoWithId createTicketInfoWithId(String field, TicketInfo ticketInfo) {
+        return new TicketInfoWithId(parseTicketId(field),
+                ticketInfo.startSaleTime(),
+                ticketInfo.endSaleTime());
+    }
+
+    private boolean isTicketOnSale(TicketInfo ticketInfo, LocalDateTime currentTime) {
+        return (ticketInfo.startSaleTime().isBefore(currentTime) || ticketInfo.startSaleTime().isEqual(currentTime))
+                && (ticketInfo.endSaleTime().isAfter(currentTime) || ticketInfo.endSaleTime().isEqual(currentTime));
     }
 
     /**
@@ -45,7 +105,21 @@ public class TicketInfoRedisRepository extends RedisRepository {
         Assert.notNull(startSaleTime, "티켓 판매 시작 시각은 null 일 수 없습니다.");
         Assert.notNull(endSaleTime, "티켓 판매 종료 시각은 null 일 수 없습니다.");
 
-        redisTemplate.opsForHash().put(TICKETS_PREFIX + ticketId, TICKET_INFO_START_SALE_TIME_PREFIX, startSaleTime.toString());
-        redisTemplate.opsForHash().put(TICKETS_PREFIX + ticketId, TICKET_INFO_END_SALE_TIME_PREFIX, endSaleTime.toString());
+        try {
+            TicketInfo ticketInfo = new TicketInfo(startSaleTime, endSaleTime);
+            String value = mapper.writeValueAsString(ticketInfo);
+
+            hashOperations.put(TICKET_INFO_KEY, formatField(ticketId), value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private String formatField(Long ticketId) {
+        return "tickets:" + ticketId;
+    }
+
+    private Long parseTicketId(String field) {
+        return Long.parseLong(field.split(":")[1]);
     }
 }

--- a/backend/core/src/main/java/com/wootecam/festivals/global/utils/TimeProvider.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/global/utils/TimeProvider.java
@@ -1,5 +1,6 @@
 package com.wootecam.festivals.global.utils;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import org.springframework.stereotype.Component;
 
@@ -8,5 +9,9 @@ public class TimeProvider {
 
     public LocalDateTime getCurrentTime() {
         return LocalDateTime.now();
+    }
+
+    public long getCurrentTimeInMilli() {
+        return Instant.now().toEpochMilli();
     }
 }

--- a/backend/core/src/main/java/com/wootecam/festivals/global/utils/TimeProvider.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/global/utils/TimeProvider.java
@@ -2,10 +2,13 @@ package com.wootecam.festivals.global.utils;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TimeProvider {
+
+    public static final ZoneOffset KTC_ZONE = ZoneOffset.of("+9");
 
     public LocalDateTime getCurrentTime() {
         return LocalDateTime.now();

--- a/backend/core/src/test/java/com/wootecam/festivals/domain/ticket/repository/TicketInfoRedisRepositoryTest.java
+++ b/backend/core/src/test/java/com/wootecam/festivals/domain/ticket/repository/TicketInfoRedisRepositoryTest.java
@@ -1,0 +1,134 @@
+package com.wootecam.festivals.domain.ticket.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootecam.festivals.domain.ticket.entity.TicketInfo;
+import com.wootecam.festivals.domain.ticket.entity.TicketInfoWithId;
+import com.wootecam.festivals.utils.TestApplication;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = TestApplication.class)
+@ActiveProfiles("test")
+class TicketInfoRedisRepositoryTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @Autowired
+    private TicketInfoRedisRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate.delete(TicketInfoRedisRepository.TICKET_INFO_KEY);
+    }
+
+    @Test
+    @DisplayName("티켓 정보를 조회할 수 있다")
+    void getTicketInfo_Success() throws JsonProcessingException {
+        // Given
+        Long ticketId = 1L;
+        LocalDateTime now = LocalDateTime.now();
+        TicketInfo ticketInfo = new TicketInfo(now, now.plusHours(2));
+        String jsonValue = mapper.writeValueAsString(ticketInfo);
+
+        redisTemplate.opsForHash().put(TicketInfoRedisRepository.TICKET_INFO_KEY, "tickets:" + ticketId, jsonValue);
+
+        // When
+        TicketInfo result = repository.getTicketInfo(ticketId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.startSaleTime()).isEqualTo(now);
+        assertThat(result.endSaleTime()).isEqualTo(now.plusHours(2));
+    }
+
+    @Test
+    @DisplayName("티켓 정보가 없다면 null을 반환한다")
+    void getTicketInfo_NotFound() {
+        // Given
+        Long ticketId = 2L;
+
+        // When
+        TicketInfo result = repository.getTicketInfo(ticketId);
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("현재 판매 중인 티켓들의 정보를 조회할 수 있다")
+    void getTicketsWithSaleStarted_Success() throws JsonProcessingException {
+        // Given
+        LocalDateTime now = LocalDateTime.now();
+        TicketInfo ticketInfo1 = new TicketInfo(now.minusHours(1), now.plusHours(1));
+        TicketInfo ticketInfo2 = new TicketInfo(now.minusHours(2), now.minusHours(1));
+        String jsonValue1 = mapper.writeValueAsString(ticketInfo1);
+        String jsonValue2 = mapper.writeValueAsString(ticketInfo2);
+
+        redisTemplate.opsForHash().put(TicketInfoRedisRepository.TICKET_INFO_KEY, "tickets:1", jsonValue1);
+        redisTemplate.opsForHash().put(TicketInfoRedisRepository.TICKET_INFO_KEY, "tickets:2", jsonValue2);
+
+        // When
+        List<TicketInfoWithId> result = repository.getTicketsWithSaleStarted();
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).ticketId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("현재 판매 중인 티켓이 없다면 빈 리스트를 반환한다")
+    void getTicketsWithSaleStarted_Empty() {
+        // When
+        List<TicketInfoWithId> result = repository.getTicketsWithSaleStarted();
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("주어진 티켓 정보를 저장한다")
+    void setTicketInfo_Success() throws JsonProcessingException {
+        // Given
+        Long ticketId = 1L;
+        LocalDateTime start = LocalDateTime.now();
+        LocalDateTime end = start.plusHours(2);
+
+        // When
+        repository.setTicketInfo(ticketId, start, end);
+
+        // Then
+        String storedValue = (String) redisTemplate.opsForHash()
+                .get(TicketInfoRedisRepository.TICKET_INFO_KEY, "tickets:" + ticketId);
+        assertThat(storedValue).isNotNull();
+
+        TicketInfo ticketInfo = mapper.readValue(storedValue, TicketInfo.class);
+        assertThat(ticketInfo.startSaleTime()).isEqualTo(start);
+        assertThat(ticketInfo.endSaleTime()).isEqualTo(end);
+    }
+
+    @Test
+    @DisplayName("티켓 정보가 제대로 주어지지 않았다면 예외를 반환한다")
+    void setTicketInfo_JsonProcessingException() {
+        // Given
+        Long ticketId = 1L;
+        LocalDateTime start = LocalDateTime.now();
+
+        // When Then
+        assertThrows(IllegalArgumentException.class, () -> repository.setTicketInfo(ticketId, start, null));
+    }
+}

--- a/backend/core/src/test/java/com/wootecam/festivals/global/utils/TimeProviderTest.java
+++ b/backend/core/src/test/java/com/wootecam/festivals/global/utils/TimeProviderTest.java
@@ -1,0 +1,44 @@
+package com.wootecam.festivals.global.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TimeProviderTest {
+
+    @Test
+    void getCurrentTime_ReturnsFixedTime() {
+        // Given
+        TimeProvider timeProvider = Mockito.spy(new TimeProvider());
+        LocalDateTime fixedTime = LocalDateTime.of(2025, 3, 8, 12, 0, 0);
+
+        // Mocking: 특정 메서드의 결과를 고정
+        doReturn(fixedTime).when(timeProvider).getCurrentTime();
+
+        // When
+        LocalDateTime result = timeProvider.getCurrentTime();
+
+        // Then
+        assertThat(result).isEqualTo(fixedTime);
+    }
+
+    @Test
+    void getCurrentTimeInMilli_ReturnsFixedEpochMilli() {
+        // Given
+        TimeProvider timeProvider = Mockito.spy(new TimeProvider());
+        Instant fixedInstant = Instant.ofEpochMilli(1736308800000L); // 2025-03-08 12:00:00 UTC
+
+        // Mocking
+        doReturn(fixedInstant.toEpochMilli()).when(timeProvider).getCurrentTimeInMilli();
+
+        // When
+        long result = timeProvider.getCurrentTimeInMilli();
+
+        // Then
+        assertThat(result).isEqualTo(1736308800000L);
+    }
+}

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   api-server:
     build:
@@ -39,6 +37,8 @@ services:
       - redis
     environment:
       - SPRING_PROFILES_ACTIVE=docker
+    networks:
+      - app-network
 
   schedule-server:
     build:
@@ -48,6 +48,19 @@ services:
       - "8083:8080"
     depends_on:
       - mysql
+      - redis
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+    networks:
+      - app-network
+
+  queue-manager-server:
+    build:
+      context: ./queue-manager-server
+      dockerfile: Dockerfile
+    ports:
+      - "8084:8080"  # Expose queue-server on port 8084
+    depends_on:
       - redis
     environment:
       - SPRING_PROFILES_ACTIVE=docker

--- a/backend/mysql/init/init.sql
+++ b/backend/mysql/init/init.sql
@@ -1,3 +1,8 @@
+CREATE DATABASE IF NOT EXISTS `twodari`;
+CREATE DATABASE IF NOT EXISTS `schedule`;
+
+USE`twodari`;
+
 create table if not exists twodari.checkin
 (
     is_checked
@@ -237,11 +242,7 @@ create table if not exists twodari.ticket_stock
 create unique index ticket_stock_ticket_id_ticket_stock_member_id_index
     on twodari.ticket_stock (ticket_id, ticket_stock_member_id);
 
-
-CREATE
-DATABASE IF NOT EXISTS schedule;
-USE
-schedule;
+USE `schedule`;
 
 CREATE TABLE IF NOT EXISTS QRTZ_JOB_DETAILS
 (

--- a/backend/mysql/init/init.sql
+++ b/backend/mysql/init/init.sql
@@ -60,8 +60,7 @@ create table if not exists twodari.festival
 (
     6
 ) not null,
-    festival_id bigint auto_increment
-    primary key,
+    festival_id bigint auto_increment primary key,
     festival_start_time datetime
 (
     6
@@ -127,12 +126,52 @@ create table if not exists twodari.member
 (
     255
 ) null,
-    constraint UKmbmcqelty0fbrvxp1q58dn57t
-    unique
+    constraint UKmbmcqelty0fbrvxp1q58dn57t unique
 (
     email
 )
     );
+
+create table if not exists twodari.payment
+(
+    payment_id
+    bigint
+    auto_increment
+    primary
+    key,
+    payment_uuid
+    varchar
+(
+    255
+) not null unique,
+    payment_time datetime
+(
+    6
+) not null,
+    payment_status enum
+(
+    'INITIATED',
+    'IN_PROGRESS',
+    'SUCCESS',
+    'FAILED_CLIENT',
+    'FAILED_SERVER'
+) not null,
+    created_at datetime
+(
+    6
+) not null,
+    updated_at datetime
+(
+    6
+) not null,
+    purchase_id bigint not null
+    );
+
+create index payment_purchase_id_index
+    on twodari.payment (purchase_id);
+
+create index payment_payment_uuid_index
+    on twodari.payment (payment_uuid);
 
 create table if not exists twodari.purchase
 (
@@ -142,8 +181,11 @@ create table if not exists twodari.purchase
     6
 ) not null,
     member_id bigint not null,
-    purchase_id bigint auto_increment
-    primary key,
+    purchase_id bigint auto_increment primary key,
+    payment_uuid varchar
+(
+    255
+),
     purchase_time datetime
 (
     6
@@ -155,7 +197,9 @@ create table if not exists twodari.purchase
 ) not null,
     purchase_status enum
 (
-    'PURCHASED',
+    'INITIATED',
+    'PAID',
+    'CANCELED',
     'REFUNDED'
 ) not null
     );
@@ -165,6 +209,9 @@ create index purchase_member_id_index
 
 create index purchase_ticket_id_index
     on twodari.purchase (ticket_id);
+
+create index purchase_payment_uuid_index
+    on twodari.purchase (payment_uuid);
 
 create table if not exists twodari.ticket
 (

--- a/backend/payment-server/src/main/resources/application.yml
+++ b/backend/payment-server/src/main/resources/application.yml
@@ -11,8 +11,8 @@ spring:
     password: ${DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
-      maximum-pool-size: 50 # ?? ??? ? ????? ??
-      minimum-idle: 50 # ?? idle ??? ? ????? ??
+      maximum-pool-size: 50
+      minimum-idle: 50
 
   data:
     redis:
@@ -111,8 +111,7 @@ spring:
 
   data:
     redis:
-#      host: redis
-      host: localhost
+      host: redis
       port: 6379
       password: ""
 

--- a/backend/queue-manager-server/Dockerfile
+++ b/backend/queue-manager-server/Dockerfile
@@ -1,0 +1,7 @@
+FROM bellsoft/liberica-openjdk-alpine:17.0.12
+
+WORKDIR /app
+
+COPY build/libs/queue-manager-server-0.0.1-SNAPSHOT.jar /app/app.jar
+
+ENTRYPOINT ["java", "-Duser.timezone=Asia/Seoul", "-jar", "/app/app.jar"]

--- a/backend/queue-manager-server/build.gradle
+++ b/backend/queue-manager-server/build.gradle
@@ -1,0 +1,2 @@
+dependencies {
+}

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/QueueManagerApplication.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/QueueManagerApplication.java
@@ -1,0 +1,14 @@
+package com.wootecam.festivals;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class QueueManagerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(QueueManagerApplication.class, args);
+    }
+}

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/dto/UpdateWaitOrder.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/dto/UpdateWaitOrder.java
@@ -1,0 +1,6 @@
+package com.wootecam.festivals.domain.queue.dto;
+
+public record UpdateWaitOrder(Long ticketId,
+                              Integer waitOrder,
+                              long updatedAt) {
+}

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/dto/WaitOrder.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/dto/WaitOrder.java
@@ -1,0 +1,5 @@
+package com.wootecam.festivals.domain.queue.dto;
+
+public record WaitOrder(Integer waitOrder,
+                        long currentTime) {
+}

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
@@ -75,12 +75,6 @@ public class RedisWaitOrderListRepository {
         return result;
     }
 
-    public void updateWaitOrderList(Long festivalId, Integer newWaitOrder) throws JsonProcessingException {
-        String value = formatValue(newWaitOrder);
-
-        hashOperations.put(WAIT_ORDER_LIST_KEY, formatField(festivalId), value);
-    }
-
     public void updateWaitOrderListBulk(Map<Long, Integer> updates) {
         // Serialize to Json
         Map<String, String> formattedUpdates = updates.entrySet().stream()

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
@@ -1,0 +1,79 @@
+package com.wootecam.festivals.domain.queue.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootecam.festivals.domain.queue.dto.UpdateWaitOrder;
+import com.wootecam.festivals.domain.queue.dto.WaitOrder;
+import com.wootecam.festivals.global.utils.TimeProvider;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 티켓 기반 대기열 시스템 정보를 Hash로 관리하는 redis 레포지토리
+ * <p> field: ticket:{ticketId} </p>
+ * <p> value: 현재 대기열 진입 가능 범위(min, max), 티켓 판매 시작/종료 시각, 대기열 진입 가능 범위 업데이트된 시각 </p>
+ */
+@Repository
+public class RedisWaitOrderListRepository {
+
+    public static final String WAIT_ORDER_LIST_KEY = "current_wait_order_list";
+
+    private final HashOperations<String, String, String> hashOperations;
+
+    private final ObjectMapper mapper;
+    private final TimeProvider timeProvider;
+
+    public RedisWaitOrderListRepository(RedisTemplate<String, String> redisTemplate,
+                                        ObjectMapper mapper,
+                                        TimeProvider timeProvider) {
+        this.hashOperations = redisTemplate.opsForHash();
+        this.mapper = mapper;
+        this.timeProvider = timeProvider;
+    }
+
+    public List<UpdateWaitOrder> getAllWaitOrder() {
+        Map<String, String> entries = hashOperations.entries(WAIT_ORDER_LIST_KEY);
+        if (entries.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return entries.entrySet().stream()
+                .map(entry -> {
+                    try {
+                        Long festivalId = parseFestivalIdFromWaitOrderListKey(entry.getKey());
+                        WaitOrder waitOrder = mapper.readValue(entry.getValue(), WaitOrder.class);
+
+                        return new UpdateWaitOrder(festivalId, waitOrder.waitOrder(), waitOrder.currentTime());
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException("Failed to parse wait order JSON", e);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    public void updateWaitOrderList(Long festivalId, Integer newWaitOrder) throws JsonProcessingException {
+        String value = formatWaitOrderListValue(newWaitOrder);
+
+        hashOperations.put(WAIT_ORDER_LIST_KEY, formatWaitOrderListKey(festivalId), value);
+    }
+
+    private String formatWaitOrderListKey(Long festivalId) {
+        return "ticket:" + festivalId;
+    }
+
+    private Long parseFestivalIdFromWaitOrderListKey(String orderListKey) {
+        return Long.parseLong(orderListKey.split(":")[1]);
+    }
+
+    private String formatWaitOrderListValue(Integer waitOrder) throws JsonProcessingException {
+        long currentTime = timeProvider.getCurrentTimeInMilli();
+        WaitOrder waitOrderDto = new WaitOrder(waitOrder, currentTime);
+
+        return mapper.writeValueAsString(waitOrderDto);
+    }
+}

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
@@ -4,12 +4,17 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wootecam.festivals.domain.queue.dto.UpdateWaitOrder;
 import com.wootecam.festivals.domain.queue.dto.WaitOrder;
+import com.wootecam.festivals.domain.ticket.entity.TicketInfoWithId;
 import com.wootecam.festivals.global.utils.TimeProvider;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -19,10 +24,12 @@ import org.springframework.stereotype.Repository;
  * <p> value: 현재 대기열 진입 가능 범위(min, max), 티켓 판매 시작/종료 시각, 대기열 진입 가능 범위 업데이트된 시각 </p>
  */
 @Repository
+@Slf4j
 public class RedisWaitOrderListRepository {
 
     public static final String WAIT_ORDER_LIST_KEY = "current_wait_order_list";
 
+    private final RedisTemplate<String, String> redisTemplate;
     private final HashOperations<String, String, String> hashOperations;
 
     private final ObjectMapper mapper;
@@ -31,46 +38,90 @@ public class RedisWaitOrderListRepository {
     public RedisWaitOrderListRepository(RedisTemplate<String, String> redisTemplate,
                                         ObjectMapper mapper,
                                         TimeProvider timeProvider) {
+        this.redisTemplate = redisTemplate;
         this.hashOperations = redisTemplate.opsForHash();
         this.mapper = mapper;
         this.timeProvider = timeProvider;
     }
 
-    public List<UpdateWaitOrder> getAllWaitOrder() {
-        Map<String, String> entries = hashOperations.entries(WAIT_ORDER_LIST_KEY);
-        if (entries.isEmpty()) {
+    public List<UpdateWaitOrder> getAllIn(List<TicketInfoWithId> tickets) {
+        if (tickets.isEmpty()) {
             return Collections.emptyList();
         }
 
-        return entries.entrySet().stream()
-                .map(entry -> {
-                    try {
-                        Long festivalId = parseFestivalIdFromWaitOrderListKey(entry.getKey());
-                        WaitOrder waitOrder = mapper.readValue(entry.getValue(), WaitOrder.class);
-
-                        return new UpdateWaitOrder(festivalId, waitOrder.waitOrder(), waitOrder.currentTime());
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException("Failed to parse wait order JSON", e);
-                    }
-                })
+        // 요청할 필드 리스트 생성
+        List<String> ticketKeys = tickets.stream()
+                .map(ticket -> formatField(ticket.ticketId()))
                 .collect(Collectors.toList());
+
+        // Redis에서 해당 필드만 조회
+        List<String> values = hashOperations.multiGet(WAIT_ORDER_LIST_KEY, ticketKeys);
+
+        List<UpdateWaitOrder> result = new ArrayList<>();
+        for (int i = 0; i < values.size(); i++) {
+            String value = values.get(i);
+            if (value == null) {
+                continue;
+            }
+
+            try {
+                WaitOrder waitOrder = mapper.readValue(value, WaitOrder.class);
+                Long ticketId = tickets.get(i).ticketId();
+                result.add(new UpdateWaitOrder(ticketId, waitOrder.waitOrder(), waitOrder.currentTime()));
+            } catch (JsonProcessingException e) {
+                log.error("Failed to parse wait order JSON for ticket: {}", tickets.get(i).ticketId(), e);
+            }
+        }
+        return result;
     }
 
     public void updateWaitOrderList(Long festivalId, Integer newWaitOrder) throws JsonProcessingException {
-        String value = formatWaitOrderListValue(newWaitOrder);
+        String value = formatValue(newWaitOrder);
 
-        hashOperations.put(WAIT_ORDER_LIST_KEY, formatWaitOrderListKey(festivalId), value);
+        hashOperations.put(WAIT_ORDER_LIST_KEY, formatField(festivalId), value);
     }
 
-    private String formatWaitOrderListKey(Long festivalId) {
-        return "ticket:" + festivalId;
+    public void updateWaitOrderListBulk(Map<Long, Integer> updates) {
+        // Serialize to Json
+        Map<String, String> formattedUpdates = updates.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> formatField(entry.getKey()),
+                        entry -> {
+                            try {
+                                return formatValue(entry.getValue());
+                            } catch (JsonProcessingException e) {
+                                log.error("Failed to serialize wait order JSON for ticket: {}", entry.getKey(), e);
+                                return null;
+                            }
+                        }
+                ));
+
+        formattedUpdates.values().removeIf(Objects::isNull);
+
+        if (formattedUpdates.isEmpty()) {
+            log.warn("No valid wait orders to update in bulk");
+            return;
+        }
+
+        List<Object> results = redisTemplate.executePipelined((RedisCallback<?>) (connection) -> {
+            formattedUpdates.forEach((key, value) -> {
+                try {
+                    connection.hashCommands().hSet(WAIT_ORDER_LIST_KEY.getBytes(), key.getBytes(), value.getBytes());
+                } catch (Exception e) {
+                    log.error("Failed to update wait order: ticketKey={}, value={}", key, value, e);
+                }
+            });
+            return null;
+        });
+
+        log.info("Bulk update completed. Success: {}, Total Requests: {}", results.size(), formattedUpdates.size());
     }
 
-    private Long parseFestivalIdFromWaitOrderListKey(String orderListKey) {
-        return Long.parseLong(orderListKey.split(":")[1]);
+    private String formatField(Long ticketId) {
+        return "tickets:" + ticketId;
     }
 
-    private String formatWaitOrderListValue(Integer waitOrder) throws JsonProcessingException {
+    private String formatValue(Integer waitOrder) throws JsonProcessingException {
         long currentTime = timeProvider.getCurrentTimeInMilli();
         WaitOrder waitOrderDto = new WaitOrder(waitOrder, currentTime);
 

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
@@ -60,9 +60,6 @@ public class RedisWaitOrderListRepository {
         List<UpdateWaitOrder> result = new ArrayList<>();
         for (int i = 0; i < values.size(); i++) {
             String value = values.get(i);
-            if (value == null) {
-                continue;
-            }
 
             try {
                 WaitOrder waitOrder = mapper.readValue(value, WaitOrder.class);

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateService.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateService.java
@@ -43,6 +43,10 @@ public class WaitOrderUpdateService {
             }
         }
 
+        if (updateTickets.isEmpty()) {
+            log.warn("No valid wait orders to update in bulk");
+            return;
+        }
         waitOrderListRepository.updateWaitOrderListBulk(updateTickets);
         log.info("Updated Wait order.");
     }

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateService.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateService.java
@@ -1,13 +1,13 @@
 package com.wootecam.festivals.domain.queue.service;
 
-import static com.wootecam.festivals.global.utils.TimeProvider.KTC_ZONE;
-
 import com.wootecam.festivals.domain.queue.dto.UpdateWaitOrder;
 import com.wootecam.festivals.domain.queue.repository.RedisWaitOrderListRepository;
-import com.wootecam.festivals.domain.ticket.entity.TicketInfo;
+import com.wootecam.festivals.domain.ticket.entity.TicketInfoWithId;
 import com.wootecam.festivals.domain.ticket.repository.TicketInfoRedisRepository;
 import com.wootecam.festivals.global.utils.TimeProvider;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -28,31 +28,26 @@ public class WaitOrderUpdateService {
 
     @Scheduled(fixedRate = 5000)
     public void updateWaitOrders() {
-        List<UpdateWaitOrder> waitOrders = waitOrderListRepository.getAllWaitOrder();
-        log.info("wait order list: " + waitOrders.toString());
+        // 현재 판매 중인 티켓의 대기열 진입 범위 조회
+        List<TicketInfoWithId> ticketsWithSaleStarted = ticketInfoRedisRepository.getTicketsWithSaleStarted();
+        List<UpdateWaitOrder> waitOrders = waitOrderListRepository.getAllIn(ticketsWithSaleStarted);
+        log.info("wait order list: {}", waitOrders.toString());
 
+        // 대기열 진입 범위 갱신
         long currentTime = timeProvider.getCurrentTimeInMilli();
+        Map<Long, Integer> updateTickets = new HashMap<>();
         for (UpdateWaitOrder wo : waitOrders) {
             if (isUpdatable(wo, currentTime)) {
                 Integer newWaitOrder = wo.waitOrder() + INCREMENT_VALUE;
-                try {
-                    waitOrderListRepository.updateWaitOrderList(wo.ticketId(), newWaitOrder);
-                    log.info("Updated Wait order successfully: ticket:" + wo.ticketId()
-                            + ", newWaitOrder: " + newWaitOrder);
-                } catch (Exception e) {
-                    log.error("Cannot update wait order: ticket: " + wo.ticketId() + ", newWaitOrder: "
-                            + newWaitOrder, e);
-                }
+                updateTickets.put(wo.ticketId(), newWaitOrder);
             }
         }
+
+        waitOrderListRepository.updateWaitOrderListBulk(updateTickets);
+        log.info("Updated Wait order.");
     }
 
     private boolean isUpdatable(UpdateWaitOrder waitOrder, long currentTime) {
-        TicketInfo ticketInfo = ticketInfoRedisRepository.getTicketInfo(waitOrder.ticketId());
-        long startMilliTime = ticketInfo.startSaleTime().toInstant(KTC_ZONE).toEpochMilli();
-        long endMilliTime = ticketInfo.endSaleTime().toInstant(KTC_ZONE).toEpochMilli();
-
-        return startMilliTime <= currentTime && currentTime <= endMilliTime
-                && currentTime - waitOrder.updatedAt() >= UPDATE_THRESHOLD;
+        return currentTime - waitOrder.updatedAt() >= UPDATE_THRESHOLD;
     }
 }

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateService.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateService.java
@@ -1,0 +1,58 @@
+package com.wootecam.festivals.domain.queue.service;
+
+import static com.wootecam.festivals.global.utils.TimeProvider.KTC_ZONE;
+
+import com.wootecam.festivals.domain.queue.dto.UpdateWaitOrder;
+import com.wootecam.festivals.domain.queue.repository.RedisWaitOrderListRepository;
+import com.wootecam.festivals.domain.ticket.entity.TicketInfo;
+import com.wootecam.festivals.domain.ticket.repository.TicketInfoRedisRepository;
+import com.wootecam.festivals.global.utils.TimeProvider;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WaitOrderUpdateService {
+
+    private static final long UPDATE_THRESHOLD = 5000;
+    private static final int INCREMENT_VALUE = 100;
+
+    private final RedisWaitOrderListRepository waitOrderListRepository;
+    private final TicketInfoRedisRepository ticketInfoRedisRepository;
+
+    private final TimeProvider timeProvider;
+
+    @Scheduled(fixedRate = 5000)
+    public void updateWaitOrders() {
+        List<UpdateWaitOrder> waitOrders = waitOrderListRepository.getAllWaitOrder();
+        log.info("wait order list: " + waitOrders.toString());
+
+        long currentTime = timeProvider.getCurrentTimeInMilli();
+        for (UpdateWaitOrder wo : waitOrders) {
+            if (isUpdatable(wo, currentTime)) {
+                Integer newWaitOrder = wo.waitOrder() + INCREMENT_VALUE;
+                try {
+                    waitOrderListRepository.updateWaitOrderList(wo.ticketId(), newWaitOrder);
+                    log.info("Updated Wait order successfully: ticket:" + wo.ticketId()
+                            + ", newWaitOrder: " + newWaitOrder);
+                } catch (Exception e) {
+                    log.error("Cannot update wait order: ticket: " + wo.ticketId() + ", newWaitOrder: "
+                            + newWaitOrder, e);
+                }
+            }
+        }
+    }
+
+    private boolean isUpdatable(UpdateWaitOrder waitOrder, long currentTime) {
+        TicketInfo ticketInfo = ticketInfoRedisRepository.getTicketInfo(waitOrder.ticketId());
+        long startMilliTime = ticketInfo.startSaleTime().toInstant(KTC_ZONE).toEpochMilli();
+        long endMilliTime = ticketInfo.endSaleTime().toInstant(KTC_ZONE).toEpochMilli();
+
+        return startMilliTime <= currentTime && currentTime <= endMilliTime
+                && currentTime - waitOrder.updatedAt() >= UPDATE_THRESHOLD;
+    }
+}

--- a/backend/queue-manager-server/src/main/resources/application.yml
+++ b/backend/queue-manager-server/src/main/resources/application.yml
@@ -1,0 +1,69 @@
+spring:
+  profiles:
+    active: local
+  session:
+    store-type: redis
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: ""
+
+logging:
+  level:
+    org.hibernate.SQL: off
+    com.wootecam.festivals: debug
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+
+server:
+  port: 8084
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  data:
+    redis:
+      host: ${secret-redis.host}
+      port: ${secret-redis.port}
+      password: ${secret-redis.password}
+    task:
+      execution:
+        pool:
+          core-size: 15
+          max-size: 50
+          queue-capacity: 2000
+
+logging:
+  level:
+    org.hibernate.SQL: off
+    com.wootecam.festivals: error
+    org.hibernate.engine.internal.StatisticalLoggingSessionEventListener: off
+
+---
+spring:
+  config:
+    activate:
+      on-profile: docker
+
+  data:
+    redis:
+      host: redis
+      port: 6379
+      password: ""
+
+logging:
+  level:
+    com.wootecam.festivals: debug

--- a/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepositoryTest.java
+++ b/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepositoryTest.java
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wootecam.festivals.domain.queue.dto.UpdateWaitOrder;
 import com.wootecam.festivals.domain.queue.dto.WaitOrder;
 import com.wootecam.festivals.domain.ticket.entity.TicketInfoWithId;
-import com.wootecam.festivals.domain.ticket.repository.TicketInfoRedisRepository;
 import com.wootecam.festivals.global.utils.TimeProvider;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
@@ -33,16 +32,10 @@ class RedisWaitOrderListRepositoryTest {
     private RedisTemplate<String, String> redisTemplate;
 
     @Autowired
-    private StringRedisTemplate stringRedisTemplate;
-
-    @Autowired
     private ObjectMapper objectMapper;
 
     @Autowired
     private TimeProvider timeProvider;
-
-    @Autowired
-    private TicketInfoRedisRepository ticketInfoRedisRepository;
 
     private RedisWaitOrderListRepository repository;
 
@@ -90,5 +83,23 @@ class RedisWaitOrderListRepositoryTest {
         assertNotNull(storedValue);
         WaitOrder storedOrder = objectMapper.readValue(storedValue, WaitOrder.class);
         assertEquals(600, storedOrder.waitOrder());
+    }
+
+    @Test
+    @DisplayName("주어진 티켓 id가 없으면 대기열 순번을 갱신하지 않는다")
+    void doesNotUpdateIfTicketIdNonExist() throws JsonProcessingException {
+        // Given
+        WaitOrder waitOrder = new WaitOrder(500, 10000L);
+        String jsonValue = objectMapper.writeValueAsString(waitOrder);
+        hashOperations.put(RedisWaitOrderListRepository.WAIT_ORDER_LIST_KEY, "tickets:1", jsonValue);
+
+        // When
+        repository.updateWaitOrderListBulk(Collections.EMPTY_MAP);
+
+        // Then
+        String storedValue = hashOperations.get(RedisWaitOrderListRepository.WAIT_ORDER_LIST_KEY, "tickets:1");
+        assertNotNull(storedValue);
+        WaitOrder storedOrder = objectMapper.readValue(storedValue, WaitOrder.class);
+        assertEquals(500, storedOrder.waitOrder());
     }
 }

--- a/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepositoryTest.java
+++ b/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.wootecam.festivals.domain.queue.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootecam.festivals.domain.queue.dto.UpdateWaitOrder;
+import com.wootecam.festivals.domain.queue.dto.WaitOrder;
+import com.wootecam.festivals.domain.ticket.entity.TicketInfoWithId;
+import com.wootecam.festivals.domain.ticket.repository.TicketInfoRedisRepository;
+import com.wootecam.festivals.global.utils.TimeProvider;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+class RedisWaitOrderListRepositoryTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TimeProvider timeProvider;
+
+    @Autowired
+    private TicketInfoRedisRepository ticketInfoRedisRepository;
+
+    private RedisWaitOrderListRepository repository;
+
+    private HashOperations<String, String, String> hashOperations;
+
+    @BeforeEach
+    void setUp() {
+        repository = new RedisWaitOrderListRepository(redisTemplate, objectMapper, timeProvider);
+        hashOperations = redisTemplate.opsForHash();
+    }
+
+    @Test
+    @DisplayName("주어진 티켓 id에 해당하는 대기열 순번을 조회할 수 있다")
+    void getAllIn_returnsUpdateWaitOrders() throws JsonProcessingException {
+        // Given
+        TicketInfoWithId ticket1 = new TicketInfoWithId(1L, null, null);
+        List<TicketInfoWithId> tickets = List.of(ticket1);
+
+        WaitOrder waitOrder = new WaitOrder(500, 10000L);
+        String jsonValue = objectMapper.writeValueAsString(waitOrder);
+        hashOperations.put(RedisWaitOrderListRepository.WAIT_ORDER_LIST_KEY, "tickets:1", jsonValue);
+
+        // When
+        List<UpdateWaitOrder> result = repository.getAllIn(tickets);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).ticketId()).isEqualTo(1L);
+        assertThat(result.get(0).waitOrder()).isEqualTo(500);
+        assertThat(result.get(0).updatedAt()).isEqualTo(10000L);
+    }
+
+    @Test
+    @DisplayName("주어진 티켓 id와 대기열 순번으로 갱신할 수 있다")
+    void updateWaitOrderListBulk_updatesRedis() throws JsonProcessingException {
+        // Given
+        Map<Long, Integer> updates = new HashMap<>();
+        updates.put(1L, 600);
+
+        // When
+        repository.updateWaitOrderListBulk(updates);
+
+        // Then
+        String storedValue = hashOperations.get(RedisWaitOrderListRepository.WAIT_ORDER_LIST_KEY, "tickets:1");
+        assertNotNull(storedValue);
+        WaitOrder storedOrder = objectMapper.readValue(storedValue, WaitOrder.class);
+        assertEquals(600, storedOrder.waitOrder());
+    }
+}

--- a/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateServiceTest.java
+++ b/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateServiceTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -41,6 +42,7 @@ class WaitOrderUpdateServiceTest {
     }
 
     @Test
+    @DisplayName("현재 판매 중인 티켓만 대기열 범위 갱신할 수 있다")
     void updateWaitOrders_updatesEligibleWaitOrders() {
         // Given
         TicketInfoWithId ticket1 = new TicketInfoWithId(1L, null, null);
@@ -66,6 +68,7 @@ class WaitOrderUpdateServiceTest {
     }
 
     @Test
+    @DisplayName("현재 판매 중인 티켓이 없으면 대기열 범위를 갱신하지 않는다")
     void updateWaitOrders_doesNotUpdateIfNotEligible() {
         // Given
         TicketInfoWithId ticket1 = new TicketInfoWithId(1L, null, null);

--- a/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateServiceTest.java
+++ b/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateServiceTest.java
@@ -1,0 +1,86 @@
+package com.wootecam.festivals.domain.queue.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.wootecam.festivals.domain.queue.dto.UpdateWaitOrder;
+import com.wootecam.festivals.domain.queue.repository.RedisWaitOrderListRepository;
+import com.wootecam.festivals.domain.ticket.entity.TicketInfoWithId;
+import com.wootecam.festivals.domain.ticket.repository.TicketInfoRedisRepository;
+import com.wootecam.festivals.global.utils.TimeProvider;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WaitOrderUpdateServiceTest {
+
+    @Mock
+    private RedisWaitOrderListRepository waitOrderListRepository;
+
+    @Mock
+    private TicketInfoRedisRepository ticketInfoRedisRepository;
+
+    @Mock
+    private TimeProvider timeProvider;
+
+    @InjectMocks
+    private WaitOrderUpdateService waitOrderUpdateService;
+
+    @BeforeEach
+    void setUp() {
+        when(timeProvider.getCurrentTimeInMilli()).thenReturn(10000L);
+    }
+
+    @Test
+    void updateWaitOrders_updatesEligibleWaitOrders() {
+        // Given
+        TicketInfoWithId ticket1 = new TicketInfoWithId(1L, null, null);
+        TicketInfoWithId ticket2 = new TicketInfoWithId(2L, null, null);
+        List<TicketInfoWithId> tickets = List.of(ticket1, ticket2);
+
+        UpdateWaitOrder waitOrder1 = new UpdateWaitOrder(1L, 500, 4000L);
+        UpdateWaitOrder waitOrder2 = new UpdateWaitOrder(2L, 300, 6000L);
+        List<UpdateWaitOrder> waitOrders = List.of(waitOrder1, waitOrder2);
+
+        when(ticketInfoRedisRepository.getTicketsWithSaleStarted()).thenReturn(tickets);
+        when(waitOrderListRepository.getAllIn(tickets)).thenReturn(waitOrders);
+
+        // expects
+        Map<Long, Integer> expectedUpdates = new HashMap<>();
+        expectedUpdates.put(1L, 600); // only ticket1 should be updated
+
+        // When
+        waitOrderUpdateService.updateWaitOrders();
+
+        // Then
+        verify(waitOrderListRepository).updateWaitOrderListBulk(expectedUpdates);
+    }
+
+    @Test
+    void updateWaitOrders_doesNotUpdateIfNotEligible() {
+        // Given
+        TicketInfoWithId ticket1 = new TicketInfoWithId(1L, null, null);
+        List<TicketInfoWithId> tickets = List.of(ticket1);
+
+        UpdateWaitOrder waitOrder1 = new UpdateWaitOrder(1L, 500, 9000L); // Not eligible (9000L + 5000 > 10000L)
+        List<UpdateWaitOrder> waitOrders = List.of(waitOrder1);
+
+        when(ticketInfoRedisRepository.getTicketsWithSaleStarted()).thenReturn(tickets);
+        when(waitOrderListRepository.getAllIn(tickets)).thenReturn(waitOrders);
+
+        // When
+        waitOrderUpdateService.updateWaitOrders();
+
+        // Then
+        verify(waitOrderListRepository, never()).updateWaitOrderListBulk(any());
+    }
+}

--- a/backend/queue-manager-server/src/test/java/com/wootecam/festivals/utils/EmbeddedRedisConfig.java
+++ b/backend/queue-manager-server/src/test/java/com/wootecam/festivals/utils/EmbeddedRedisConfig.java
@@ -1,0 +1,42 @@
+package com.wootecam.festivals.utils;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+@Configuration
+@Profile("test")
+public class EmbeddedRedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private String REDIS_PORT;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void redisServer() throws IOException {
+        redisServer = new RedisServer(Integer.parseInt(REDIS_PORT));
+        try {
+            redisServer.start();
+        } catch (Exception e) {
+            System.out.println("Redis server start failed");
+            e.printStackTrace();
+        }
+    }
+
+    @PreDestroy
+    public void stopRedis() throws IOException {
+        if (redisServer != null) {
+            try {
+                redisServer.stop();
+            } catch (Exception e) {
+                System.out.println("Redis server stop failed");
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/backend/queue-manager-server/src/test/resources/application.yml
+++ b/backend/queue-manager-server/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  profiles:
+    active:
+      test
+  data:
+    redis:
+      host: localhost
+      port: 6378
+      password: ""
+
+server:
+  port: 8080
+
+logging:
+  level:
+    com.wootecam.festivals: debug
+

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/festival/service/FestivalSchedulerService.java
@@ -41,10 +41,8 @@ public class FestivalSchedulerService {
                 .orElseThrow(() -> new ApiException(FESTIVAL_NOT_FOUND));
 
         log.debug("Festival 스케줄링 - ID: {}", festival.getId());
-        log.debug("현재 시간 : {}", LocalDateTime.now());
         log.debug("시작 시간 : {}", festival.getStartTime());
         log.debug("종료 시간 : {}", festival.getEndTime());
-
 
         scheduleStartTimeUpdate(findFestival);
         scheduleEndTimeUpdate(findFestival);

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/queue/dto/WaitOrder.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/queue/dto/WaitOrder.java
@@ -1,0 +1,4 @@
+package com.wootecam.festivals.domain.queue.dto;
+
+public record WaitOrder(Integer waitOrder, long currentTime) {
+}

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
@@ -1,0 +1,46 @@
+package com.wootecam.festivals.domain.queue.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootecam.festivals.domain.queue.dto.WaitOrder;
+import com.wootecam.festivals.global.utils.TimeProvider;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RedisWaitOrderListRepository {
+
+    public static final String WAIT_ORDER_LIST_KEY = "current_wait_order_list";
+
+    private final HashOperations<String, String, String> hashOperations;
+
+    private final ObjectMapper mapper;
+    private final TimeProvider timeProvider;
+
+    public RedisWaitOrderListRepository(RedisTemplate<String, String> redisTemplate,
+                                        ObjectMapper mapper,
+                                        TimeProvider timeProvider) {
+        this.hashOperations = redisTemplate.opsForHash();
+        this.mapper = mapper;
+        this.timeProvider = timeProvider;
+    }
+
+    public void initializeWaitOrderList(Long ticketId)
+            throws JsonProcessingException {
+        String value = formatWaitOrderListValue(0);
+
+        hashOperations.put(WAIT_ORDER_LIST_KEY, formatWaitOrderListKey(ticketId), value);
+    }
+
+    private String formatWaitOrderListKey(Long ticketId) {
+        return "ticket:" + ticketId;
+    }
+
+    private String formatWaitOrderListValue(Integer newWaitOrder) throws JsonProcessingException {
+        long currentTime = timeProvider.getCurrentTimeInMilli();
+        WaitOrder waitOrderDto = new WaitOrder(newWaitOrder, currentTime);
+
+        return mapper.writeValueAsString(waitOrderDto);
+    }
+}

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepository.java
@@ -34,7 +34,7 @@ public class RedisWaitOrderListRepository {
     }
 
     private String formatWaitOrderListKey(Long ticketId) {
-        return "ticket:" + ticketId;
+        return "tickets:" + ticketId;
     }
 
     private String formatWaitOrderListValue(Integer newWaitOrder) throws JsonProcessingException {

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleJob.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleJob.java
@@ -3,6 +3,7 @@ package com.wootecam.festivals.domain.ticket.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wootecam.festivals.domain.festival.dto.TicketResponse;
+import com.wootecam.festivals.domain.queue.repository.RedisWaitOrderListRepository;
 import com.wootecam.festivals.domain.ticket.repository.CurrentTicketWaitRedisRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketInfoRedisRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockCountRedisRepository;
@@ -22,6 +23,7 @@ public class TicketScheduleJob implements Job {
     private final TicketInfoRedisRepository ticketInfoRedisRepository;
     private final TicketStockCountRedisRepository ticketStockCountRedisRepository;
     private final CurrentTicketWaitRedisRepository currentTicketWaitRedisRepository;
+    private final RedisWaitOrderListRepository waitOrderListRepository;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -30,9 +32,11 @@ public class TicketScheduleJob implements Job {
         try {
             String ticketToJson = jobExecutionContext.getJobDetail().getJobDataMap().getString("ticket");
             TicketResponse ticket = objectMapper.readValue(ticketToJson, TicketResponse.class);
+
             ticketInfoRedisRepository.setTicketInfo(ticket.id(), ticket.startSaleTime(), ticket.endSaleTime());
             ticketStockCountRedisRepository.setTicketStockCount(ticket.id(), ticket.remainStock());
-            currentTicketWaitRedisRepository.addCurrentTicketWait(ticket.id());
+            waitOrderListRepository.initializeWaitOrderList(ticket.id());
+            currentTicketWaitRedisRepository.addCurrentTicketWait(ticket.id()); // todo: 대기열 시스템 변경 후 삭제
 
             log.info("티켓 정보 업데이트 스케줄러 실행 완료 - 티켓 ID: {}, 판매 시작 시각: {}, 판매 종료 시각: {}, 남은 재고: {}", ticket.id(),
                     ticket.startSaleTime(), ticket.endSaleTime(), ticket.remainStock());

--- a/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleService.java
+++ b/backend/schedule-server/src/main/java/com/wootecam/festivals/domain/ticket/service/TicketScheduleService.java
@@ -3,7 +3,6 @@ package com.wootecam.festivals.domain.ticket.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wootecam.festivals.domain.festival.dto.TicketResponse;
-import com.wootecam.festivals.domain.ticket.repository.TicketRepository;
 import com.wootecam.festivals.global.exception.GlobalErrorCode;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import java.time.LocalDateTime;
@@ -24,7 +23,6 @@ import org.springframework.stereotype.Service;
 public class TicketScheduleService {
 
     private final Scheduler scheduler;
-    private final TicketRepository ticketRepository;
     private final ObjectMapper objectMapper;
 
     /**

--- a/backend/schedule-server/src/test/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepositoryTest.java
+++ b/backend/schedule-server/src/test/java/com/wootecam/festivals/domain/queue/repository/RedisWaitOrderListRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.wootecam.festivals.domain.queue.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootecam.festivals.domain.queue.dto.WaitOrder;
+import com.wootecam.festivals.global.utils.TimeProvider;
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+class RedisWaitOrderListRepositoryTest extends SpringBootTestConfig {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TimeProvider timeProvider;
+
+    private RedisWaitOrderListRepository repository;
+
+    private HashOperations<String, String, String> hashOperations;
+
+    @BeforeEach
+    void setUp() {
+        repository = new RedisWaitOrderListRepository(redisTemplate, objectMapper, timeProvider);
+        hashOperations = redisTemplate.opsForHash();
+    }
+
+    @Test
+    @DisplayName("주어진 ticketId의 대기열 순번을 0으로 초기화할 수 있다")
+    void initializeWaitOrderList_storesInitialValueInRedis() throws JsonProcessingException {
+        // Given
+        Long ticketId = 1L;
+        String expectedKey = "tickets:1";
+
+        // When
+        repository.initializeWaitOrderList(ticketId);
+
+        // Then
+        String storedValue = hashOperations.get(RedisWaitOrderListRepository.WAIT_ORDER_LIST_KEY, expectedKey);
+        assertNotNull(storedValue);
+        WaitOrder storedOrder = objectMapper.readValue(storedValue, WaitOrder.class);
+        assertEquals(0, storedOrder.waitOrder());
+    }
+}

--- a/backend/settings.gradle
+++ b/backend/settings.gradle
@@ -5,3 +5,5 @@ include 'api-server'
 include 'payment-server'
 include 'schedule-server'
 include 'e2e'
+include 'queue-manager-server'
+


### PR DESCRIPTION
## 📄 작업 설명

대기열 순번을 갱신하는 모듈 구현

## 🚨 관련 이슈
- closes #25 

## 🌈 작업 상황

- 티켓 판매 스케줄링 작업 시 대기열 순번 초기화하는 로직 추가
- 판매 중인 티켓의 경우, 일정 간격마다 대기열 순번을 갱신하는 로직 추가
  - 판매 중인 티켓의 판매 시각 정보를 벌크 조회
  - 판매 중인 티켓의 대기열 순번을 벌크 갱신
- 성능 향상을 위해 티켓 판매 시각을 redis에 저장하는 TicketInfoRedisRepository에서 사용하는 Hash 구조 변경
