### PR TITLE
Feat#23: 대기열 통신 서버 기능 구현

### DIFF
--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/repository/AvailablePurchaseMemberRedisRepository.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/repository/AvailablePurchaseMemberRedisRepository.java
@@ -1,0 +1,57 @@
+package com.wootecam.festivals.domain.purchase.repository;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AvailablePurchaseMemberRedisRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private String createKey(Long ticketId) {
+        return "tickets:" + ticketId + ":availableMembers";
+    }
+
+    /**
+     * 구매 가능 유저 추가
+     */
+    public void addAvailableMember(Long ticketId, Long memberId, Long ttl) {
+        String key = createKey(ticketId);
+        redisTemplate.opsForSet().add(key, String.valueOf(memberId));
+        redisTemplate.expire(key, ttl, TimeUnit.MINUTES);
+    }
+
+    /**
+     * 구매 가능 유저 제거
+     */
+    public void removeAvailableMember(Long ticketId, Long memberId) {
+        redisTemplate.opsForSet().remove(createKey(ticketId), String.valueOf(memberId));
+    }
+
+    /**
+     * 특정 유저가 구매 가능 목록에 있는지 확인
+     */
+    public boolean isAvailable(Long ticketId, Long memberId) {
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForSet().isMember(createKey(ticketId), String.valueOf(memberId))
+        );
+    }
+
+    /**
+     * 구매 가능 유저 전체 조회
+     */
+    public Set<String> getAllAvailableMembers(Long ticketId) {
+        return redisTemplate.opsForSet().members(createKey(ticketId));
+    }
+
+    /**
+     * 전체 제거 (필요시)
+     */
+    public void clear(Long ticketId) {
+        redisTemplate.delete(createKey(ticketId));
+    }
+}

--- a/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
+++ b/backend/api-server/src/main/java/com/wootecam/festivals/domain/purchase/service/PurchaseService.java
@@ -5,6 +5,7 @@ import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.purchase.dto.PurchasableResponse;
 import com.wootecam.festivals.domain.purchase.dto.PurchasePreviewInfoResponse;
 import com.wootecam.festivals.domain.purchase.exception.PurchaseErrorCode;
+import com.wootecam.festivals.domain.purchase.repository.AvailablePurchaseMemberRedisRepository;
 import com.wootecam.festivals.domain.purchase.repository.PurchaseRepository;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.domain.ticket.entity.TicketStock;
@@ -39,6 +40,7 @@ public class PurchaseService {
     private final TicketRepository ticketRepository;
     private final UuidProvider uuidProvider;
     private final PurchaseSessionRedisRepository purchaseSessionRedisRepository;
+    private final AvailablePurchaseMemberRedisRepository availablePurchaseMemberRedisRepository;
     @Value("${purchase.session.ttl:5}")
     private Long purchaseSessionTtl;
 
@@ -77,6 +79,7 @@ public class PurchaseService {
         Member member = memberRepository.getReferenceById(loginMemberId);
         validFirstTicketPurchase(ticket, member);
         validFirstTicketStockReservation(ticket, member);
+        validAvailablePurchaseMember(ticketId, loginMemberId);
 
         Optional<TicketStock> optionalTicketStock = getTicketStockForUpdate(ticket);
         if (optionalTicketStock.isEmpty() || optionalTicketStock.get().isReserved()) {
@@ -201,6 +204,13 @@ public class PurchaseService {
         if (ticketStockRepository.existsByTicketAndMember(ticket, member.getId())) {
             log.warn("이미 티켓 재고를 예약한 회원입니다. 티켓 ID: {}, 회원 ID: {}", ticket.getId(), member.getId());
             throw new ApiException(TicketErrorCode.ALREADY_RESERVED_TICKET_STOCK);
+        }
+    }
+
+    private void validAvailablePurchaseMember(Long ticketId, Long loginMemberId) {
+        if (!availablePurchaseMemberRedisRepository.isAvailable(ticketId, loginMemberId)) {
+            log.warn("구매 가능한 회원이 아닙니다. 티켓 ID: {}, 회원 ID: {}", ticketId, loginMemberId);
+            throw new ApiException(PurchaseErrorCode.INVALID_PURCHASE_SESSION);
         }
     }
 }

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/PurchaseSyncTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/PurchaseSyncTest.java
@@ -10,6 +10,7 @@ import com.wootecam.festivals.domain.festival.repository.FestivalRepository;
 import com.wootecam.festivals.domain.member.entity.Member;
 import com.wootecam.festivals.domain.member.repository.MemberRepository;
 import com.wootecam.festivals.domain.purchase.dto.PurchasableResponse;
+import com.wootecam.festivals.domain.purchase.repository.AvailablePurchaseMemberRedisRepository;
 import com.wootecam.festivals.domain.purchase.service.PurchaseService;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.domain.ticket.entity.TicketStock;
@@ -49,6 +50,8 @@ class PurchaseSyncTest extends SpringBootTestConfig {
     private TicketStockRepository ticketStockRepository;
     @Autowired
     private TicketStockJdbcRepository ticketStockJdbcRepository;
+    @Autowired
+    private AvailablePurchaseMemberRedisRepository availablePurchaseMemberRedisRepository;
 
     @BeforeEach
     void setup() {
@@ -66,6 +69,7 @@ class PurchaseSyncTest extends SpringBootTestConfig {
         Ticket ticket = createTicket(festival, ticketCount);
 
         List<Member> customers = createMembers(customerCount);
+
         ExecutorService executorService = Executors.newFixedThreadPool(customerCount);
         CountDownLatch latch = new CountDownLatch(customerCount);
 
@@ -76,7 +80,7 @@ class PurchaseSyncTest extends SpringBootTestConfig {
         for (Member customer : customers) {
             executorService.submit(() -> {
                 try {
-
+                    availablePurchaseMemberRedisRepository.addAvailableMember(ticket.getId(), customer.getId(), 1L);
                     PurchasableResponse purchasableResponse = purchaseService.checkPurchasable(ticket.getId(),
                             customer.getId(), LocalDateTime.now());
                     if (purchasableResponse.purchasable()) {

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/repository/AvailablePurchaseMemberRedisRepositoryTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/repository/AvailablePurchaseMemberRedisRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.wootecam.festivals.domain.purchase.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@DisplayName("AvailablePurchaseMemberRedisRepository")
+class AvailablePurchaseMemberRedisRepositoryTest extends SpringBootTestConfig {
+
+    private final Long ticketId = 1L;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+    @Autowired
+    private AvailablePurchaseMemberRedisRepository repository;
+
+    @BeforeEach
+    void clearRedis() {
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {2L, 3L})
+    @DisplayName("addAvailableMember 로 추가된 회원은 조회된다")
+    void add_and_check(Long memberId) {
+        repository.addAvailableMember(ticketId, memberId, 1L);
+        assertThat(repository.isAvailable(ticketId, memberId)).isTrue();
+    }
+
+    @Test
+    @DisplayName("removeAvailableMember 는 회원을 삭제한다")
+    void remove_available_member() {
+        repository.addAvailableMember(ticketId, 2L, 1L);
+        repository.removeAvailableMember(ticketId, 2L);
+        assertThat(repository.isAvailable(ticketId, 2L)).isFalse();
+    }
+
+    @Test
+    @DisplayName("getAllAvailableMembers 는 모든 회원을 반환한다")
+    void get_all_members() {
+        repository.addAvailableMember(ticketId, 2L, 1L);
+        repository.addAvailableMember(ticketId, 3L, 1L);
+        Set<String> members = repository.getAllAvailableMembers(ticketId);
+        assertThat(members).containsExactlyInAnyOrder("2", "3");
+    }
+
+    @Test
+    @DisplayName("clear 는 모든 데이터를 삭제한다")
+    void clear_all() {
+        repository.addAvailableMember(ticketId, 2L, 1L);
+        repository.clear(ticketId);
+        assertThat(repository.getAllAvailableMembers(ticketId)).isEmpty();
+    }
+}

--- a/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
+++ b/backend/api-server/src/test/java/com/wootecam/festivals/domain/purchase/service/PurchaseServiceTest.java
@@ -18,6 +18,7 @@ import com.wootecam.festivals.domain.purchase.dto.PurchasePreviewInfoResponse;
 import com.wootecam.festivals.domain.purchase.entity.Purchase;
 import com.wootecam.festivals.domain.purchase.entity.PurchaseStatus;
 import com.wootecam.festivals.domain.purchase.exception.PurchaseErrorCode;
+import com.wootecam.festivals.domain.purchase.repository.AvailablePurchaseMemberRedisRepository;
 import com.wootecam.festivals.domain.purchase.repository.PurchaseRepository;
 import com.wootecam.festivals.domain.ticket.entity.Ticket;
 import com.wootecam.festivals.domain.ticket.entity.TicketStock;
@@ -50,6 +51,7 @@ class PurchaseServiceTest extends SpringBootTestConfig {
     private final PurchaseRepository purchaseRepository;
     private final RedisTemplate<String, String> redisTemplate;
     private final PurchaseSessionRedisRepository purchaseSessionRedisRepository;
+    private final AvailablePurchaseMemberRedisRepository availablePurchaseMemberRedisRepository;
 
     private LocalDateTime ticketSaleStartTime = LocalDateTime.now();
     private Festival festival;
@@ -62,7 +64,8 @@ class PurchaseServiceTest extends SpringBootTestConfig {
                                PurchaseRepository purchaseRepository, CheckinRepository checkinRepository,
                                TicketStockJdbcRepository ticketStockJdbcRepository,
                                RedisTemplate<String, String> redisTemplate,
-                               PurchaseSessionRedisRepository purchaseSessionRedisRepository) {
+                               PurchaseSessionRedisRepository purchaseSessionRedisRepository,
+                               AvailablePurchaseMemberRedisRepository availablePurchaseMemberRedisRepository) {
         this.purchaseService = purchaseService;
         this.memberRepository = memberRepository;
         this.festivalRepository = festivalRepository;
@@ -72,6 +75,7 @@ class PurchaseServiceTest extends SpringBootTestConfig {
         this.ticketStockJdbcRepository = ticketStockJdbcRepository;
         this.redisTemplate = redisTemplate;
         this.purchaseSessionRedisRepository = purchaseSessionRedisRepository;
+        this.availablePurchaseMemberRedisRepository = availablePurchaseMemberRedisRepository;
     }
 
     @BeforeEach
@@ -104,6 +108,7 @@ class PurchaseServiceTest extends SpringBootTestConfig {
                     .festival(festival)
                     .build());
             ticketStockRepository.save(TicketStock.builder().ticket(ticket).build());
+            availablePurchaseMemberRedisRepository.addAvailableMember(ticket.getId(), member.getId(), 2L);
         }
 
         @Test
@@ -145,7 +150,7 @@ class PurchaseServiceTest extends SpringBootTestConfig {
             void It_return_cannot_purchasable_response() {
                 Member newMember = Member.builder().name("newMember").email("email").build();
                 memberRepository.save(newMember);
-
+                availablePurchaseMemberRedisRepository.addAvailableMember(ticket.getId(), newMember.getId(), 2L);
                 PurchasableResponse purchasableResponse = purchaseService.checkPurchasable(ticket.getId(),
                         newMember.getId(), LocalDateTime.now());
 

--- a/backend/core/src/main/java/com/wootecam/festivals/domain/queue/constant/QueueRedisStreamConstants.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/domain/queue/constant/QueueRedisStreamConstants.java
@@ -1,0 +1,10 @@
+package com.wootecam.festivals.domain.queue.constant;
+
+public class QueueRedisStreamConstants {
+
+    public static final String PASS_ORDER_STREAM_KEY = "pass-order-stream";
+    public static final String PASS_ORDER_STREAM_GROUP = "pass-order-stream-group";
+
+    private QueueRedisStreamConstants() {
+    }
+}

--- a/backend/core/src/main/java/com/wootecam/festivals/domain/queue/dto/PassOrderMessage.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/domain/queue/dto/PassOrderMessage.java
@@ -1,0 +1,4 @@
+package com.wootecam.festivals.domain.queue.dto;
+
+public record PassOrderMessage(Long ticketId, Long passOrder) {
+}

--- a/backend/core/src/main/java/com/wootecam/festivals/global/config/RedisStreamInitializer.java
+++ b/backend/core/src/main/java/com/wootecam/festivals/global/config/RedisStreamInitializer.java
@@ -6,12 +6,13 @@ import static com.wootecam.festivals.domain.payment.constant.PaymentRedisStreamC
 import static com.wootecam.festivals.domain.payment.constant.PaymentRedisStreamConstants.PAYMENT_REQUEST_STREAM_KEY;
 import static com.wootecam.festivals.domain.payment.constant.PaymentRedisStreamConstants.PAYMENT_RESULT_STREAM_GROUP;
 import static com.wootecam.festivals.domain.payment.constant.PaymentRedisStreamConstants.PAYMENT_RESULT_STREAM_KEY;
+import static com.wootecam.festivals.domain.queue.constant.QueueRedisStreamConstants.PASS_ORDER_STREAM_GROUP;
+import static com.wootecam.festivals.domain.queue.constant.QueueRedisStreamConstants.PASS_ORDER_STREAM_KEY;
 import static com.wootecam.festivals.domain.ticket.constant.TicketRedisStreamConstants.TICKET_STREAM_GROUP;
 import static com.wootecam.festivals.domain.ticket.constant.TicketRedisStreamConstants.TICKET_STREAM_KEY;
 
 import com.wootecam.festivals.global.utils.RedisStreamOperator;
 import jakarta.annotation.PostConstruct;
-import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -37,6 +38,7 @@ public class RedisStreamInitializer {
                     initializeStream(TICKET_STREAM_KEY, TICKET_STREAM_GROUP);
                     initializeStream(PAYMENT_REQUEST_STREAM_KEY, PAYMENT_REQUEST_STREAM_GROUP);
                     initializeStream(PAYMENT_RESULT_STREAM_KEY, PAYMENT_RESULT_STREAM_GROUP);
+                    initializeStream(PASS_ORDER_STREAM_KEY, PASS_ORDER_STREAM_GROUP);
 
                     redisTemplate.opsForValue().set(initKey, "true"); // 초기화 완료 기록
                 }

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/PassOrderEventProducer.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/PassOrderEventProducer.java
@@ -10,14 +10,16 @@ import com.wootecam.festivals.global.exception.GlobalErrorCode;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.data.redis.connection.stream.ObjectRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.connection.stream.StreamRecords;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-@Service
+@Component
+@DependsOn(value = {"redisConnectionFactory", "redisStreamInitializer"})
 @RequiredArgsConstructor
 public class PassOrderEventProducer {
 

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/PassOrderEventProducer.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/PassOrderEventProducer.java
@@ -1,0 +1,41 @@
+package com.wootecam.festivals.domain.queue.service;
+
+
+import static com.wootecam.festivals.domain.queue.constant.QueueRedisStreamConstants.PASS_ORDER_STREAM_KEY;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootecam.festivals.domain.queue.dto.PassOrderMessage;
+import com.wootecam.festivals.global.exception.GlobalErrorCode;
+import com.wootecam.festivals.global.exception.type.ApiException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamRecords;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PassOrderEventProducer {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void send(PassOrderMessage message) {
+        try {
+            String json = objectMapper.writeValueAsString(message);
+            ObjectRecord<String, String> record = StreamRecords.newRecord().ofObject(json)
+                    .withStreamKey(PASS_ORDER_STREAM_KEY);
+            RecordId recordId = redisTemplate.opsForStream().add(record);
+            if (recordId == null) {
+                throw new ApiException(GlobalErrorCode.INTERNAL_SERVER_ERROR);
+            }
+            log.debug("pass order event sent: {}", message);
+        } catch (JsonProcessingException e) {
+            throw new ApiException(GlobalErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+}

--- a/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateService.java
+++ b/backend/queue-manager-server/src/main/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateService.java
@@ -1,5 +1,6 @@
 package com.wootecam.festivals.domain.queue.service;
 
+import com.wootecam.festivals.domain.queue.dto.PassOrderMessage;
 import com.wootecam.festivals.domain.queue.dto.UpdateWaitOrder;
 import com.wootecam.festivals.domain.queue.repository.RedisWaitOrderListRepository;
 import com.wootecam.festivals.domain.ticket.entity.TicketInfoWithId;
@@ -23,6 +24,7 @@ public class WaitOrderUpdateService {
 
     private final RedisWaitOrderListRepository waitOrderListRepository;
     private final TicketInfoRedisRepository ticketInfoRedisRepository;
+    private final PassOrderEventProducer passOrderEventProducer;
 
     private final TimeProvider timeProvider;
 
@@ -48,6 +50,9 @@ public class WaitOrderUpdateService {
             return;
         }
         waitOrderListRepository.updateWaitOrderListBulk(updateTickets);
+        updateTickets.keySet().stream()
+                .map(ticketId -> new PassOrderMessage(ticketId, updateTickets.get(ticketId).longValue()))
+                .forEach(passOrderEventProducer::send);
         log.info("Updated Wait order.");
     }
 

--- a/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/service/PassOrderEventProducerTest.java
+++ b/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/service/PassOrderEventProducerTest.java
@@ -1,0 +1,65 @@
+package com.wootecam.festivals.domain.queue.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootecam.festivals.domain.queue.dto.PassOrderMessage;
+import com.wootecam.festivals.global.exception.type.ApiException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class PassOrderEventProducerTest {
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private StreamOperations<String, Object, Object> streamOperations;
+    @InjectMocks
+    private PassOrderEventProducer producer;
+
+    @Test
+    @DisplayName("send 는 메시지를 Redis 스트림에 기록한다")
+    void send_success() throws Exception {
+        PassOrderMessage message = new PassOrderMessage(1L, 2L);
+        when(objectMapper.writeValueAsString(message)).thenReturn("{json}");
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        when(streamOperations.add(any(ObjectRecord.class))).thenReturn(RecordId.of("0-1"));
+
+        producer.send(message);
+
+        verify(streamOperations).add(any(ObjectRecord.class));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"record"})
+    @DisplayName("오류 발생 시 ApiException 을 던진다")
+    void send_failures(String mode) throws Exception {
+        PassOrderMessage message = new PassOrderMessage(1L, 2L);
+        when(redisTemplate.opsForStream()).thenReturn(streamOperations);
+        if (mode.equals("json")) {
+            when(objectMapper.writeValueAsString(message)).thenThrow(new JsonProcessingException("err") {
+            });
+        } else {
+            when(objectMapper.writeValueAsString(message)).thenReturn("{json}");
+            when(streamOperations.add(any(ObjectRecord.class))).thenReturn(null);
+        }
+        assertThatThrownBy(() -> producer.send(message)).isInstanceOf(ApiException.class);
+    }
+}

--- a/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateServiceTest.java
+++ b/backend/queue-manager-server/src/test/java/com/wootecam/festivals/domain/queue/service/WaitOrderUpdateServiceTest.java
@@ -31,6 +31,9 @@ class WaitOrderUpdateServiceTest {
     private TicketInfoRedisRepository ticketInfoRedisRepository;
 
     @Mock
+    private PassOrderEventProducer passOrderEventProducer;
+
+    @Mock
     private TimeProvider timeProvider;
 
     @InjectMocks

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/controller/WaitOrderController.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/controller/WaitOrderController.java
@@ -1,19 +1,13 @@
 package com.wootecam.festivals.domain.wait.controller;
 
-import com.wootecam.festivals.domain.wait.dto.WaitOrderRequest;
 import com.wootecam.festivals.domain.wait.dto.WaitOrderResponse;
 import com.wootecam.festivals.domain.wait.service.WaitOrderService;
-import com.wootecam.festivals.domain.wait.session.WaitSessionRegistry;
 import com.wootecam.festivals.global.api.ApiResponse;
 import com.wootecam.festivals.global.auth.AuthUser;
 import com.wootecam.festivals.global.auth.Authentication;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,8 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class WaitOrderController {
 
     private final WaitOrderService waitOrderService;
-    private final SimpMessagingTemplate messagingTemplate;
-    private final WaitSessionRegistry sessionRegistry;
 
     /**
      * 대기열 통과 가능 여부 및 대기 순서 조회 API
@@ -47,31 +39,5 @@ public class WaitOrderController {
                                                            @RequestParam(required = false) Long waitOrder) {
         WaitOrderResponse response = waitOrderService.getWaitOrder(ticketId, authentication.memberId(), waitOrder);
         return ApiResponse.of(response);
-    }
-
-    /**
-     * 대기열에 참여하는 API 이 API는 WebSocket을 통해 호출되며, 대기열에 참여한 사용자의 세션 정보를 등록합니다.
-     *
-     * @param festivalId     대기열이 속한 축제 ID
-     * @param ticketId       대기열이 속한 티켓 ID
-     * @param memberId       대기열에 참여하는 사용자의 ID
-     * @param request        대기열 참여 요청 정보
-     * @param headerAccessor WebSocket 세션 정보를 포함하는 헤더 액세서
-     * @return 대기열 참여 응답
-     */
-    @MessageMapping("/wait/{festivalId}/tickets/{ticketId}/join")
-    public void joinQueue(@DestinationVariable Long festivalId,
-                          @DestinationVariable Long ticketId,
-                          @AuthUser Long memberId,
-                          WaitOrderRequest request,
-                          SimpMessageHeaderAccessor headerAccessor) {
-        WaitOrderResponse response = waitOrderService.getWaitOrder(ticketId, memberId, request.waitOrder());
-        String sessionId = headerAccessor.getSessionId();
-        sessionRegistry.register(sessionId, ticketId, memberId, request.waitOrder());
-        messagingTemplate.convertAndSendToUser(memberId.toString(), "/queue/wait/" + ticketId, response);
-        if (response.purchasable()) {
-            waitOrderService.removeWaiting(sessionId, ticketId, memberId);
-            waitOrderService.addAvailablePurchaseMember(ticketId, memberId);
-        }
     }
 }

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/controller/WaitOrderController.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/controller/WaitOrderController.java
@@ -1,13 +1,19 @@
 package com.wootecam.festivals.domain.wait.controller;
 
+import com.wootecam.festivals.domain.wait.dto.WaitOrderRequest;
 import com.wootecam.festivals.domain.wait.dto.WaitOrderResponse;
 import com.wootecam.festivals.domain.wait.service.WaitOrderService;
+import com.wootecam.festivals.domain.wait.session.WaitSessionRegistry;
 import com.wootecam.festivals.global.api.ApiResponse;
 import com.wootecam.festivals.global.auth.AuthUser;
 import com.wootecam.festivals.global.auth.Authentication;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,6 +28,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class WaitOrderController {
 
     private final WaitOrderService waitOrderService;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final WaitSessionRegistry sessionRegistry;
 
     /**
      * 대기열 통과 가능 여부 및 대기 순서 조회 API
@@ -39,5 +47,31 @@ public class WaitOrderController {
                                                            @RequestParam(required = false) Long waitOrder) {
         WaitOrderResponse response = waitOrderService.getWaitOrder(ticketId, authentication.memberId(), waitOrder);
         return ApiResponse.of(response);
+    }
+
+    /**
+     * 대기열에 참여하는 API 이 API는 WebSocket을 통해 호출되며, 대기열에 참여한 사용자의 세션 정보를 등록합니다.
+     *
+     * @param festivalId     대기열이 속한 축제 ID
+     * @param ticketId       대기열이 속한 티켓 ID
+     * @param memberId       대기열에 참여하는 사용자의 ID
+     * @param request        대기열 참여 요청 정보
+     * @param headerAccessor WebSocket 세션 정보를 포함하는 헤더 액세서
+     * @return 대기열 참여 응답
+     */
+    @MessageMapping("/wait/{festivalId}/tickets/{ticketId}/join")
+    public void joinQueue(@DestinationVariable Long festivalId,
+                          @DestinationVariable Long ticketId,
+                          @AuthUser Long memberId,
+                          WaitOrderRequest request,
+                          SimpMessageHeaderAccessor headerAccessor) {
+        WaitOrderResponse response = waitOrderService.getWaitOrder(ticketId, memberId, request.waitOrder());
+        String sessionId = headerAccessor.getSessionId();
+        sessionRegistry.register(sessionId, ticketId, memberId, request.waitOrder());
+        messagingTemplate.convertAndSendToUser(memberId.toString(), "/queue/wait/" + ticketId, response);
+        if (response.purchasable()) {
+            waitOrderService.removeWaiting(sessionId, ticketId, memberId);
+            waitOrderService.addAvailablePurchaseMember(ticketId, memberId);
+        }
     }
 }

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/controller/WaitOrderWebSocketController.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/controller/WaitOrderWebSocketController.java
@@ -1,0 +1,48 @@
+package com.wootecam.festivals.domain.wait.controller;
+
+import com.wootecam.festivals.domain.wait.dto.WaitOrderRequest;
+import com.wootecam.festivals.domain.wait.dto.WaitOrderResponse;
+import com.wootecam.festivals.domain.wait.service.WaitOrderService;
+import com.wootecam.festivals.domain.wait.session.WaitSessionRegistry;
+import com.wootecam.festivals.global.auth.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class WaitOrderWebSocketController {
+
+    private final WaitOrderService waitOrderService;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final WaitSessionRegistry sessionRegistry;
+
+    /**
+     * 대기열에 참여하는 API 이 API는 WebSocket을 통해 호출되며, 대기열에 참여한 사용자의 세션 정보를 등록합니다.
+     *
+     * @param festivalId     대기열이 속한 축제 ID
+     * @param ticketId       대기열이 속한 티켓 ID
+     * @param memberId       대기열에 참여하는 사용자의 ID
+     * @param request        대기열 참여 요청 정보
+     * @param headerAccessor WebSocket 세션 정보를 포함하는 헤더 액세서
+     * @return 대기열 참여 응답
+     */
+    @MessageMapping("/wait/{festivalId}/tickets/{ticketId}/join")
+    public void joinQueue(@DestinationVariable Long festivalId,
+                          @DestinationVariable Long ticketId,
+                          @AuthUser Long memberId,
+                          WaitOrderRequest request,
+                          SimpMessageHeaderAccessor headerAccessor) {
+        WaitOrderResponse response = waitOrderService.getWaitOrder(ticketId, memberId, request.waitOrder());
+        String sessionId = headerAccessor.getSessionId();
+        sessionRegistry.register(sessionId, ticketId, memberId, request.waitOrder());
+        messagingTemplate.convertAndSendToUser(memberId.toString(), "/queue/wait/" + ticketId, response);
+        if (response.purchasable()) {
+            waitOrderService.removeWaiting(sessionId, ticketId, memberId);
+            waitOrderService.addAvailablePurchaseMember(ticketId, memberId);
+        }
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/repository/AvailablePurchaseMemberRedisRepository.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/repository/AvailablePurchaseMemberRedisRepository.java
@@ -1,0 +1,57 @@
+package com.wootecam.festivals.domain.wait.repository;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AvailablePurchaseMemberRedisRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private String createKey(Long ticketId) {
+        return "tickets:" + ticketId + ":availableMembers";
+    }
+
+    /**
+     * 구매 가능 유저 추가
+     */
+    public void addAvailableMember(Long ticketId, Long memberId, Long ttl) {
+        String key = createKey(ticketId);
+        redisTemplate.opsForSet().add(key, String.valueOf(memberId));
+        redisTemplate.expire(key, ttl, TimeUnit.MINUTES);
+    }
+
+    /**
+     * 구매 가능 유저 제거
+     */
+    public void removeAvailableMember(Long ticketId, Long memberId) {
+        redisTemplate.opsForSet().remove(createKey(ticketId), String.valueOf(memberId));
+    }
+
+    /**
+     * 특정 유저가 구매 가능 목록에 있는지 확인
+     */
+    public boolean isAvailable(Long ticketId, Long memberId) {
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForSet().isMember(createKey(ticketId), String.valueOf(memberId))
+        );
+    }
+
+    /**
+     * 구매 가능 유저 전체 조회
+     */
+    public Set<String> getAllAvailableMembers(Long ticketId) {
+        return redisTemplate.opsForSet().members(createKey(ticketId));
+    }
+
+    /**
+     * 전체 제거 (필요시)
+     */
+    public void clear(Long ticketId) {
+        redisTemplate.delete(createKey(ticketId));
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/repository/WaitingRedisRepository.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/repository/WaitingRedisRepository.java
@@ -1,12 +1,14 @@
 package com.wootecam.festivals.domain.wait.repository;
 
 import com.wootecam.festivals.domain.ticket.repository.RedisRepository;
+import java.util.Map;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
-/*
-    대기열 순번 관리를 위한 Repository
-    Waiting 은 Set 으로 구현되며, 사용자 id를 value 저장합니다.
+/**
+ * 대기열 관리를 위한 Redis Repository. 대기열은 티켓 ID를 기준으로 해시맵 형태로 저장됩니다.
+ * - key: ticketId:{ticketId}:waitings
+ * - value: userId -> order
  */
 @Repository
 public class WaitingRedisRepository extends RedisRepository {
@@ -15,26 +17,54 @@ public class WaitingRedisRepository extends RedisRepository {
         super(redisTemplate);
     }
 
-    /*
-        대기열에 사용자를 추가합니다.
+    /**
+     * 대기열에 사용자를 추가합니다.
+     *
+     * @param ticketId 티켓 ID
+     * @param userId   사용자 ID
+     * @return 대기열에서의 순서 (0부터 시작)
      */
-    public void addWaiting(Long ticketId, Long userId) {
-        redisTemplate.opsForSet().add(createKey(ticketId), String.valueOf(userId));
+    public Long addWaiting(Long ticketId, Long userId) {
+        Long getOrder = getSize(ticketId);
+        redisTemplate.opsForHash().put(createKey(ticketId), String.valueOf(userId), String.valueOf(getOrder));
+
+        return getOrder;
     }
 
-    /*
-        대기열 전체 사이즈를 반환하는 메소드
+    /**
+     * 대기열 전체 사이즈를 반환합니다.
      */
     public Long getSize(Long ticketId) {
-        return redisTemplate.opsForSet().size(createKey(ticketId));
+        return redisTemplate.opsForHash().size(createKey(ticketId));
     }
 
-    /*
-        대기열에 존재하는지 여부를 반환하는 메소드
+    /**
+     * 대기열에 사용자가 존재하는지 확인합니다.
      */
     public Boolean exists(Long ticketId, Long userId) {
-        Boolean member = redisTemplate.opsForSet().isMember(createKey(ticketId), String.valueOf(userId));
-        return redisTemplate.opsForSet().isMember(createKey(ticketId), String.valueOf(userId));
+        return redisTemplate.opsForHash().hasKey(createKey(ticketId), String.valueOf(userId));
+    }
+
+    /**
+     * 대기열에서 사용자를 제거합니다.
+     */
+    public void removeWaiting(Long ticketId, Long userId) {
+        redisTemplate.opsForHash().delete(createKey(ticketId), String.valueOf(userId));
+    }
+
+    /**
+     * 특정 사용자의 순서를 조회합니다.
+     */
+    public Long getOrder(Long ticketId, Long userId) {
+        Object order = redisTemplate.opsForHash().get(createKey(ticketId), String.valueOf(userId));
+        return order != null ? Long.parseLong(order.toString()) : null;
+    }
+
+    /**
+     * 전체 대기열 정보를 Map 형태로 반환합니다.
+     */
+    public Map<Object, Object> getAll(Long ticketId) {
+        return redisTemplate.opsForHash().entries(createKey(ticketId));
     }
 
     private String createKey(Long ticketId) {

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/PassOrderEventConsumer.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/PassOrderEventConsumer.java
@@ -1,0 +1,86 @@
+package com.wootecam.festivals.domain.wait.service;
+
+import static com.wootecam.festivals.domain.queue.constant.QueueRedisStreamConstants.PASS_ORDER_STREAM_GROUP;
+import static com.wootecam.festivals.domain.queue.constant.QueueRedisStreamConstants.PASS_ORDER_STREAM_KEY;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootecam.festivals.domain.queue.dto.PassOrderMessage;
+import com.wootecam.festivals.global.exception.GlobalErrorCode;
+import com.wootecam.festivals.global.exception.type.ApiException;
+import com.wootecam.festivals.global.utils.RedisStreamOperator;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.stream.StreamListener;
+import org.springframework.data.redis.stream.StreamMessageListenerContainer;
+import org.springframework.data.redis.stream.Subscription;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 대기열 갱신이 발생했을 때, PassOrderMessage를 수신하여 WebSocket을 통해 대기열 갱신 정보를 클라이언트에 전송하는 역할을 합니다. 이 클래스는 Redis Streams를 사용하여 메시지를
+ * 수신하고 처리합니다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PassOrderEventConsumer implements StreamListener<String, ObjectRecord<String, String>>, InitializingBean,
+        DisposableBean {
+
+    private final StringRedisTemplate redisTemplate;
+    private final RedisStreamOperator redisOperator;
+    private final ObjectMapper objectMapper;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final WaitOrderService waitOrderService;
+
+    private Subscription subscription;
+    private StreamMessageListenerContainer<String, ObjectRecord<String, String>> container;
+
+    /**
+     * Redis Streams에서 PassOrderMessage를 수신하여 WebSocket을 통해 대기열 갱신 정보를 브로드캐스트 합니다.
+     *
+     * @param message 수신된 메시지
+     */
+    @Override
+    public void onMessage(ObjectRecord<String, String> message) {
+        try {
+            PassOrderMessage pass = objectMapper.readValue(message.getValue(), PassOrderMessage.class);
+            log.info("Received PassOrderMessage: {}", pass);
+            waitOrderService.removeWaiting(pass.ticketId(), pass.passOrder());
+            messagingTemplate.convertAndSend("/topic/wait/" + pass.ticketId() + "/pass-order", pass.passOrder());
+            redisTemplate.opsForStream().acknowledge(PASS_ORDER_STREAM_KEY, PASS_ORDER_STREAM_GROUP, message.getId());
+        } catch (JsonProcessingException e) {
+            throw new ApiException(GlobalErrorCode.INTERNAL_SERVER_ERROR, e);
+        }
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        this.container = redisOperator.createStreamMessageListenerContainer();
+        this.subscription = this.container.receive(
+                Consumer.from(PASS_ORDER_STREAM_GROUP, "consumer-" + System.currentTimeMillis()),
+                StreamOffset.create(PASS_ORDER_STREAM_KEY, ReadOffset.lastConsumed()),
+                this
+        );
+        this.subscription.await(Duration.ofMillis(20));
+        this.container.start();
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        if (this.subscription != null) {
+            this.subscription.cancel();
+        }
+        if (this.container != null) {
+            this.container.stop();
+        }
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/PassOrderEventConsumer.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/PassOrderEventConsumer.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.data.redis.connection.stream.Consumer;
 import org.springframework.data.redis.connection.stream.ObjectRecord;
 import org.springframework.data.redis.connection.stream.ReadOffset;
@@ -31,6 +32,7 @@ import org.springframework.stereotype.Component;
  */
 @Slf4j
 @Component
+@DependsOn(value = {"redisConnectionFactory", "redisStreamInitializer"})
 @RequiredArgsConstructor
 public class PassOrderEventConsumer implements StreamListener<String, ObjectRecord<String, String>>, InitializingBean,
         DisposableBean {

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/WaitOrderService.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/WaitOrderService.java
@@ -1,20 +1,21 @@
 package com.wootecam.festivals.domain.wait.service;
 
 import com.wootecam.festivals.domain.ticket.entity.TicketInfo;
-import com.wootecam.festivals.domain.ticket.repository.CurrentTicketWaitRedisRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketInfoRedisRepository;
 import com.wootecam.festivals.domain.ticket.repository.TicketStockCountRedisRepository;
 import com.wootecam.festivals.domain.wait.dto.WaitOrderResponse;
 import com.wootecam.festivals.domain.wait.exception.WaitErrorCode;
+import com.wootecam.festivals.domain.wait.repository.AvailablePurchaseMemberRedisRepository;
 import com.wootecam.festivals.domain.wait.repository.PassOrderRedisRepository;
 import com.wootecam.festivals.domain.wait.repository.WaitingRedisRepository;
+import com.wootecam.festivals.domain.wait.session.WaitSessionRegistry;
+import com.wootecam.festivals.domain.wait.session.WaitSessionRegistry.SessionInfo;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.global.utils.TimeProvider;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -27,7 +28,11 @@ public class WaitOrderService {
     private final PassOrderRedisRepository passOrderRedisRepository;
     private final TicketInfoRedisRepository ticketInfoRedisRepository;
     private final TimeProvider timeProvider;
-    private final CurrentTicketWaitRedisRepository currentTicketWaitRedisRepository;
+    private final WaitSessionRegistry sessionRegistry;
+    private final AvailablePurchaseMemberRedisRepository availablePurchaseMemberRedisRepository;
+    private final WaitSessionRegistry waitSessionRegistry;
+    @Value("${wait.queue.ttl-seconds}")
+    private Long availablePurchaseMemberTtlSeconds;
 
     @Value("${wait.queue.pass-chunk-size}")
     private Long passChunkSize;
@@ -46,32 +51,31 @@ public class WaitOrderService {
 
         Boolean isWaiting = waitingRepository.exists(ticketId, loginMemberId);
 
-        Long curWaitOrder = waitOrder;
-        validWaitOrderWithWaiter(curWaitOrder, isWaiting);
+        validWaitOrderWithWaiter(waitOrder, isWaiting);
 
         // 대기열 참가 및 대기 순서 발급, 만약 현재 입장 순서 범위라면 대기열 통과
         Long currentPassOrder = getCurrentPassOrder(ticketId);
-        if (!isWaiting && curWaitOrder == null) {
+        if (!isWaiting && waitOrder == null) {
             return getNewWaitOrderForNewUser(ticketId, loginMemberId, currentPassOrder);
         }
 
         validStockRemains(ticketId);
 
         // 대기 순서가 현재 입장 순서 범위에 포함된다면 대기열 통과 가능
-        if (canPass(curWaitOrder, currentPassOrder)) {
+        if (canPass(waitOrder, currentPassOrder)) {
             ticketStockCountRedisRepository.checkAndDecreaseStock(ticketId);
-            log.debug("대기열 통과 - 사용자: {}, 대기 순서: {}", loginMemberId, curWaitOrder);
-            return new WaitOrderResponse(true, curWaitOrder - currentPassOrder, curWaitOrder);
+            log.debug("대기열 통과 - 사용자: {}, 대기 순서: {}", loginMemberId, waitOrder);
+            return new WaitOrderResponse(true, waitOrder - currentPassOrder, waitOrder);
         }
 
         // 대기 순서가 현재 입장 순서 범위의 최소값보다 작거나 같다면, 이탈 유저이므로 새로운 대기 순서 발급
-        if (curWaitOrder <= curMinPassOrder(currentPassOrder)) {
-            log.debug("이탈 유저 새 대기 순서 발급 - 사용자: {}, 대기 순서: {}", loginMemberId, curWaitOrder);
+        if (waitOrder <= curMinPassOrder(currentPassOrder)) {
+            log.debug("이탈 유저 새 대기 순서 발급 - 사용자: {}, 대기 순서: {}", loginMemberId, waitOrder);
             return getNewWaitOrderForExitedUser(ticketId, currentPassOrder);
         }
 
         // 대기가 현재 입장 순서 범위에 포함되지 않는다면 대기열 통과 불가
-        return new WaitOrderResponse(false, curWaitOrder - currentPassOrder, curWaitOrder);
+        return new WaitOrderResponse(false, waitOrder - currentPassOrder, waitOrder);
     }
 
     private WaitOrderResponse getNewWaitOrderForExitedUser(Long ticketId, Long currentPassOrder) {
@@ -134,18 +138,60 @@ public class WaitOrderService {
     }
 
     private Long joinWaitOrder(Long ticketId, Long userId) {
-        waitingRepository.addWaiting(ticketId, userId);
+        if (userId != null) {
+            return waitingRepository.addWaiting(ticketId, userId);
+        }
+
         return waitingRepository.getSize(ticketId);
     }
 
-    @Scheduled(fixedRate = 5000)
-    public void updateCurrentPassOrder() {
-        List<Long> currentTicketWait = currentTicketWaitRedisRepository.getCurrentTicketWait();
+    /**
+     * 대기열에서 사용자를 제거합니다. 이 메서드는 대기열에서 사용자를 제거하고, 해당 사용자의 세션 정보를 세션 레지스트리에서 삭제합니다.
+     *
+     * @param sessionId
+     * @param ticketId
+     * @param userId
+     */
+    public void removeWaiting(String sessionId, Long ticketId, Long userId) {
+        waitingRepository.removeWaiting(ticketId, userId);
+        sessionRegistry.remove(sessionId);
+        log.debug("대기열에서 사용자 제거 - 세션 ID: {}, 티켓 ID: {}, 사용자 ID: {}", sessionId, ticketId, userId);
+    }
 
-        for (Long ticketId : currentTicketWait) {
-            Long waitSize = waitingRepository.getSize(ticketId);
-            Long newPassOrder = passOrderRedisRepository.increase(ticketId, passChunkSize, waitSize);
-            log.debug("대기열 업데이트 - ticketId: {}, 현재 입장 순서: {}", ticketId, newPassOrder);
+    /**
+     * 대기열에서 사용자를 제거합니다. 이 메서드는 대기열에서 사용자를 제거하고, 해당 사용자의 세션 정보를 세션 레지스트리에서 삭제합니다.
+     *
+     * @param ticketId
+     * @param passOrder
+     */
+    public void removeWaiting(Long ticketId, Long passOrder) {
+        List<String> sessionIds = waitSessionRegistry.canPassMembersSessionId(ticketId);
+
+        if (sessionIds.isEmpty()) {
+            log.debug("대기열에서 제거할 세션이 없습니다. 티켓 ID: {}, 대기 순서: {}", ticketId, passOrder);
+            return;
         }
+
+        sessionIds.forEach(sessionId -> {
+            SessionInfo sessionInfo = waitSessionRegistry.get(sessionId);
+            if (sessionInfo != null && sessionInfo.order().equals(passOrder)) {
+                removeWaiting(sessionId, ticketId, sessionInfo.memberId());
+                addAvailablePurchaseMember(ticketId, sessionInfo.memberId());
+            } else {
+                log.debug("대기열에서 제거할 세션 정보가 일치하지 않습니다. 세션 ID: {}, 티켓 ID: {}, 대기 순서: {}", sessionId, ticketId,
+                        passOrder);
+            }
+        });
+    }
+
+    /**
+     * 구매 가능한 유저를 추가합니다. 이 메서드는 대기열에서 통과한 사용자를 구매 가능한 유저 목록에 추가합니다.
+     * @param ticketId
+     * @param memberId
+     */
+    public void addAvailablePurchaseMember(Long ticketId, Long memberId) {
+        availablePurchaseMemberRedisRepository.addAvailableMember(ticketId, memberId,
+                availablePurchaseMemberTtlSeconds);
+        log.info("구매 가능 유저 추가 - 티켓 ID: {}, 사용자 ID: {}", ticketId, memberId);
     }
 }

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/WaitOrderService.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/WaitOrderService.java
@@ -30,7 +30,6 @@ public class WaitOrderService {
     private final TimeProvider timeProvider;
     private final WaitSessionRegistry sessionRegistry;
     private final AvailablePurchaseMemberRedisRepository availablePurchaseMemberRedisRepository;
-    private final WaitSessionRegistry waitSessionRegistry;
     @Value("${wait.queue.ttl-seconds}")
     private Long availablePurchaseMemberTtlSeconds;
 
@@ -165,7 +164,7 @@ public class WaitOrderService {
      * @param passOrder
      */
     public void removeWaiting(Long ticketId, Long passOrder) {
-        List<String> sessionIds = waitSessionRegistry.canPassMembersSessionId(ticketId);
+        List<String> sessionIds = sessionRegistry.canPassMembersSessionId(ticketId);
 
         if (sessionIds.isEmpty()) {
             log.debug("대기열에서 제거할 세션이 없습니다. 티켓 ID: {}, 대기 순서: {}", ticketId, passOrder);
@@ -173,7 +172,7 @@ public class WaitOrderService {
         }
 
         sessionIds.forEach(sessionId -> {
-            SessionInfo sessionInfo = waitSessionRegistry.get(sessionId);
+            SessionInfo sessionInfo = sessionRegistry.get(sessionId);
             if (sessionInfo != null && sessionInfo.order().equals(passOrder)) {
                 removeWaiting(sessionId, ticketId, sessionInfo.memberId());
                 addAvailablePurchaseMember(ticketId, sessionInfo.memberId());
@@ -186,6 +185,7 @@ public class WaitOrderService {
 
     /**
      * 구매 가능한 유저를 추가합니다. 이 메서드는 대기열에서 통과한 사용자를 구매 가능한 유저 목록에 추가합니다.
+     *
      * @param ticketId
      * @param memberId
      */

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/WaitWebSocketEventListener.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/service/WaitWebSocketEventListener.java
@@ -1,0 +1,32 @@
+package com.wootecam.festivals.domain.wait.session;
+
+import com.wootecam.festivals.domain.wait.repository.WaitingRedisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+/**
+ * WebSocket 세션 종료 시 대기열 정보를 정리한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WaitWebSocketEventListener {
+
+    private final WaitSessionRegistry sessionRegistry;
+    private final WaitingRedisRepository waitingRepository;
+
+    @EventListener
+    public void handleSessionDisconnect(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String sessionId = accessor.getSessionId();
+        WaitSessionRegistry.SessionInfo info = sessionRegistry.remove(sessionId);
+        if (info != null) {
+            waitingRepository.removeWaiting(info.ticketId(), info.memberId());
+            log.debug("세션 종료 - ticketId: {}, memberId: {}", info.ticketId(), info.memberId());
+        }
+    }
+}

--- a/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/session/WaitSessionRegistry.java
+++ b/backend/queue-server/src/main/java/com/wootecam/festivals/domain/wait/session/WaitSessionRegistry.java
@@ -1,0 +1,59 @@
+package com.wootecam.festivals.domain.wait.session;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * WebSocket 세션과 대기열 정보를 매핑하는 레지스트리.
+ */
+@Component
+public class WaitSessionRegistry {
+
+    private final Map<String, SessionInfo> sessions = new ConcurrentHashMap<>();
+
+    /**
+     * 세션 ID를 사용하여 대기열 참여자의 정보를 등록합니다.
+     *
+     * @param sessionId WebSocket 세션 ID
+     * @param ticketId  대기열에 참여하는 티켓의 ID
+     * @param memberId  대기열에 참여하는 사용자의 ID
+     * @param order     대기열 참여자의 순서
+     */
+    public void register(String sessionId, Long ticketId, Long memberId, Long order) {
+        sessions.put(sessionId, new SessionInfo(ticketId, memberId, order));
+    }
+
+    public SessionInfo remove(String sessionId) {
+        return sessions.remove(sessionId);
+    }
+
+    public SessionInfo get(String sessionId) {
+        return sessions.get(sessionId);
+    }
+
+    public List<String> canPassMembersSessionId(Long ticketId) {
+        return sessions.values().stream()
+                .filter(sessionInfo -> sessionInfo.ticketId().equals(ticketId))
+                .map(sessionInfo -> getSessionId(sessionInfo))
+                .flatMap(List::stream)
+                .toList();
+    }
+
+    public List<String> getSessionId(SessionInfo sessionInfo) {
+        return sessions.entrySet().stream()
+                .filter(entry -> entry.getValue().equals(sessionInfo))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    /*
+     * 세션 정보 클래스.
+     * 이 클래스는 티켓 ID와 멤버 ID를 포함하여 대기열 참여자의 정보를 저장합니다.
+     * * @param ticketId 대기열에 참여하는 티켓의 ID
+     * @param memberId 대기열에 참여하는 사용자의 ID
+     */
+    public record SessionInfo(Long ticketId, Long memberId, Long order) {
+    }
+}

--- a/backend/queue-server/src/main/resources/application.yml
+++ b/backend/queue-server/src/main/resources/application.yml
@@ -15,6 +15,7 @@ jwt:
 wait:
   queue:
     pass-chunk-size: 150
+    ttl-seconds: 2  # TTL 값 (2분)
 ---
 spring:
   config:

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/repository/AvailablePurchaseMemberRedisRepositoryTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/repository/AvailablePurchaseMemberRedisRepositoryTest.java
@@ -1,0 +1,60 @@
+package com.wootecam.festivals.domain.wait.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@DisplayName("AvailablePurchaseMemberRedisRepository 클래스")
+class AvailablePurchaseMemberRedisRepositoryTest extends SpringBootTestConfig {
+
+    private final Long ticketId = 1L;
+    private final Long memberId = 2L;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+    @Autowired
+    private AvailablePurchaseMemberRedisRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
+    }
+
+    @Test
+    @DisplayName("addAvailableMember 는 구매 가능 유저를 추가한다")
+    void add_available_member() {
+        repository.addAvailableMember(ticketId, memberId, 1L);
+        assertThat(repository.isAvailable(ticketId, memberId)).isTrue();
+    }
+
+    @Test
+    @DisplayName("removeAvailableMember 는 구매 가능 유저를 제거한다")
+    void remove_available_member() {
+        repository.addAvailableMember(ticketId, memberId, 1L);
+        repository.removeAvailableMember(ticketId, memberId);
+        assertThat(repository.isAvailable(ticketId, memberId)).isFalse();
+    }
+
+    @Test
+    @DisplayName("getAllAvailableMembers 는 전체 구매 가능 유저를 조회한다")
+    void get_all_available_members() {
+        repository.addAvailableMember(ticketId, memberId, 1L);
+        repository.addAvailableMember(ticketId, 3L, 1L);
+        Set<String> members = repository.getAllAvailableMembers(ticketId);
+        assertThat(members).containsExactlyInAnyOrder("2", "3");
+    }
+
+    @Test
+    @DisplayName("clear 는 모든 구매 가능 유저를 삭제한다")
+    void clear_all() {
+        repository.addAvailableMember(ticketId, memberId, 1L);
+        repository.clear(ticketId);
+        assertThat(repository.getAllAvailableMembers(ticketId)).isEmpty();
+    }
+}

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/repository/WaitingRedisRepositoryTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/repository/WaitingRedisRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.wootecam.festivals.domain.wait.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.wootecam.festivals.utils.SpringBootTestConfig;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@DisplayName("WaitingRedisRepository 클래스")
+class WaitingRedisRepositoryTest extends SpringBootTestConfig {
+
+    private final Long ticketId = 1L;
+    private final Long memberId = 2L;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+    @Autowired
+    private WaitingRedisRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
+    }
+
+    @Test
+    @DisplayName("addWaiting 은 대기열에 사용자를 추가하고 순서를 반환한다")
+    void add_waiting() {
+        Long order = repository.addWaiting(ticketId, memberId);
+        assertThat(order).isZero();
+        assertThat(repository.getSize(ticketId)).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("exists 는 대기열 존재 여부를 확인한다")
+    void exists_waiting() {
+        repository.addWaiting(ticketId, memberId);
+        assertThat(repository.exists(ticketId, memberId)).isTrue();
+    }
+
+    @Test
+    @DisplayName("getOrder 는 사용자의 대기 순서를 반환한다")
+    void get_order() {
+        repository.addWaiting(ticketId, memberId);
+        assertThat(repository.getOrder(ticketId, memberId)).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("removeWaiting 은 대기열에서 사용자를 제거한다")
+    void remove_waiting() {
+        repository.addWaiting(ticketId, memberId);
+        repository.removeWaiting(ticketId, memberId);
+        assertThat(repository.exists(ticketId, memberId)).isFalse();
+    }
+
+    @Test
+    @DisplayName("getAll 은 대기열의 모든 사용자를 반환한다")
+    void get_all() {
+        repository.addWaiting(ticketId, memberId);
+        Map<Object, Object> all = repository.getAll(ticketId);
+        assertThat(all).containsEntry("2", "0");
+    }
+}

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/service/PassOrderEventConsumerTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/service/PassOrderEventConsumerTest.java
@@ -1,0 +1,62 @@
+package com.wootecam.festivals.domain.wait.service;
+
+import static com.wootecam.festivals.domain.queue.constant.QueueRedisStreamConstants.PASS_ORDER_STREAM_GROUP;
+import static com.wootecam.festivals.domain.queue.constant.QueueRedisStreamConstants.PASS_ORDER_STREAM_KEY;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wootecam.festivals.domain.queue.dto.PassOrderMessage;
+import com.wootecam.festivals.global.utils.RedisStreamOperator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.connection.stream.ObjectRecord;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+@DisplayName("PassOrderEventConsumer 클래스")
+class PassOrderEventConsumerTest {
+
+    private StringRedisTemplate redisTemplate;
+    private RedisStreamOperator redisOperator;
+    private SimpMessagingTemplate messagingTemplate;
+    private WaitOrderService waitOrderService;
+    private ObjectMapper objectMapper;
+    private PassOrderEventConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate = mock(StringRedisTemplate.class);
+        redisOperator = mock(RedisStreamOperator.class);
+        messagingTemplate = mock(SimpMessagingTemplate.class);
+        waitOrderService = mock(WaitOrderService.class);
+        objectMapper = new ObjectMapper();
+        consumer = new PassOrderEventConsumer(redisTemplate, redisOperator, objectMapper, messagingTemplate, waitOrderService);
+    }
+
+    @Test
+    @DisplayName("onMessage 메소드는 메시지를 처리하고 ack를 전송한다")
+    void on_message_process() throws Exception {
+        PassOrderMessage pass = new PassOrderMessage(1L, 3L);
+        String json = objectMapper.writeValueAsString(pass);
+        RecordId id = RecordId.autoGenerate();
+        @SuppressWarnings("unchecked")
+        ObjectRecord<String, String> record = (ObjectRecord<String, String>) mock(ObjectRecord.class);
+        when(record.getValue()).thenReturn(json);
+        when(record.getId()).thenReturn(id);
+
+        StreamOperations<String, Object, Object> ops = mock(StreamOperations.class);
+        when(redisTemplate.opsForStream()).thenReturn(ops);
+
+        consumer.onMessage(record);
+
+        verify(waitOrderService).removeWaiting(pass.ticketId(), pass.passOrder());
+        verify(messagingTemplate).convertAndSend("/topic/wait/" + pass.ticketId() + "/pass-order", pass.passOrder());
+        verify(ops).acknowledge(eq(PASS_ORDER_STREAM_KEY), eq(PASS_ORDER_STREAM_GROUP), eq(id));
+    }
+}

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/service/WaitOrderServiceTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/service/WaitOrderServiceTest.java
@@ -75,8 +75,8 @@ class WaitOrderServiceTest extends SpringBootTestConfig {
 
             // Then: 통과 가능 여부와 대기열 순서를 확인
             assertThat(response.purchasable()).isTrue();
-            assertThat(response.relativeWaitOrder()).isEqualTo(1L); // (6 - 5)
-            assertThat(response.absoluteWaitOrder()).isEqualTo(6L);
+            assertThat(response.relativeWaitOrder()).isEqualTo(0L); // (6 - 5)
+            assertThat(response.absoluteWaitOrder()).isEqualTo(5L);
 
             assertThat(waitingRepository.exists(ticketId, loginMemberId)).isTrue(); // 사용자가 대기열에 추가되었는지 확인
         }
@@ -217,42 +217,6 @@ class WaitOrderServiceTest extends SpringBootTestConfig {
             assertThatThrownBy(() -> waitOrderService.getWaitOrder(2L, loginMemberId, 8L))
                     .isInstanceOf(ApiException.class)
                     .hasFieldOrPropertyWithValue("errorCode", WaitErrorCode.INVALID_TICKET);
-        }
-    }
-
-    @Nested
-    @DisplayName("updateCurrentPassOrder 메소드는")
-    class Describe_updateCurrentPassOrder {
-        private Long ticketId1 = 1L;
-        private Long ticketId2 = 2L;
-
-        @BeforeEach
-        void setUp() {
-            currentTicketWaitRedisRepository.addCurrentTicketWait(ticketId1);
-            currentTicketWaitRedisRepository.addCurrentTicketWait(ticketId2);
-            for (int i = 0; i < 6; ++i) {
-                waitingRepository.addWaiting(ticketId1, (long) i);
-            }
-            for (int i = 0; i < 11; ++i) {
-                waitingRepository.addWaiting(ticketId2, (long) i);
-            }
-        }
-
-        @Test
-        @DisplayName("현재 진행 중인 티켓팅들의 대기열 범위를 갱신한다")
-        void it_updates_current_pass_order() {
-            // given
-            passOrderRedisRepository.set(ticketId1, 0L);
-            passOrderRedisRepository.set(ticketId2, 5L);
-
-            // when
-            waitOrderService.updateCurrentPassOrder();
-
-            // then
-            Long newPassOrder1 = passOrderRedisRepository.get(ticketId1);
-            Long newPassOrder2 = passOrderRedisRepository.get(ticketId2);
-            assertThat(newPassOrder1).isEqualTo(5L);
-            assertThat(newPassOrder2).isEqualTo(10L);
         }
     }
 }

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/service/WaitOrderServiceTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/service/WaitOrderServiceTest.java
@@ -8,8 +8,10 @@ import com.wootecam.festivals.domain.ticket.repository.TicketInfoRedisRepository
 import com.wootecam.festivals.domain.ticket.repository.TicketStockCountRedisRepository;
 import com.wootecam.festivals.domain.wait.dto.WaitOrderResponse;
 import com.wootecam.festivals.domain.wait.exception.WaitErrorCode;
+import com.wootecam.festivals.domain.wait.repository.AvailablePurchaseMemberRedisRepository;
 import com.wootecam.festivals.domain.wait.repository.PassOrderRedisRepository;
 import com.wootecam.festivals.domain.wait.repository.WaitingRedisRepository;
+import com.wootecam.festivals.domain.wait.session.WaitSessionRegistry;
 import com.wootecam.festivals.global.exception.type.ApiException;
 import com.wootecam.festivals.utils.SpringBootTestConfig;
 import java.time.LocalDateTime;
@@ -42,6 +44,10 @@ class WaitOrderServiceTest extends SpringBootTestConfig {
     private PassOrderRedisRepository passOrderRedisRepository;
     @Autowired
     private CurrentTicketWaitRedisRepository currentTicketWaitRedisRepository;
+    @Autowired
+    private WaitSessionRegistry sessionRegistry;
+    @Autowired
+    private AvailablePurchaseMemberRedisRepository availableRepository;
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
 
@@ -217,6 +223,38 @@ class WaitOrderServiceTest extends SpringBootTestConfig {
             assertThatThrownBy(() -> waitOrderService.getWaitOrder(2L, loginMemberId, 8L))
                     .isInstanceOf(ApiException.class)
                     .hasFieldOrPropertyWithValue("errorCode", WaitErrorCode.INVALID_TICKET);
+        }
+    }
+
+    @Nested
+    @DisplayName("removeWaiting 메소드는")
+    class Describe_removeWaiting {
+
+
+        @BeforeEach
+        void setUpRemove() {
+            // 대기열과 세션 정보 초기화
+            waitingRepository.addWaiting(ticketId, loginMemberId);
+            sessionRegistry.register("session", ticketId, loginMemberId, 0L);
+        }
+
+        @Test
+        @DisplayName("세션 ID와 사용자 정보를 받아 대기열과 세션을 삭제한다")
+        void remove_waiting_with_session() {
+            waitOrderService.removeWaiting("session", ticketId, loginMemberId);
+
+            assertThat(waitingRepository.exists(ticketId, loginMemberId)).isFalse();
+            assertThat(sessionRegistry.get("session")).isNull();
+        }
+
+        @Test
+        @DisplayName("대기 순서를 받아 해당 사용자를 제거하고 구매 가능 유저에 추가한다")
+        void remove_waiting_by_order() {
+            waitOrderService.removeWaiting(ticketId, 0L);
+
+            assertThat(waitingRepository.exists(ticketId, loginMemberId)).isFalse();
+            assertThat(sessionRegistry.get("session")).isNull();
+            assertThat(availableRepository.isAvailable(ticketId, loginMemberId)).isTrue();
         }
     }
 }

--- a/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/session/WaitSessionRegistryTest.java
+++ b/backend/queue-server/src/test/java/com/wootecam/festivals/domain/wait/session/WaitSessionRegistryTest.java
@@ -1,0 +1,48 @@
+package com.wootecam.festivals.domain.wait.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("WaitSessionRegistry 클래스")
+class WaitSessionRegistryTest {
+
+    private WaitSessionRegistry registry;
+
+    @BeforeEach
+    void setUp() {
+        registry = new WaitSessionRegistry();
+    }
+
+    @Test
+    @DisplayName("register 메소드는 세션 정보를 등록하고 조회할 수 있다")
+    void register_and_get() {
+        registry.register("s1", 1L, 2L, 3L);
+        WaitSessionRegistry.SessionInfo info = registry.get("s1");
+        assertThat(info.ticketId()).isEqualTo(1L);
+        assertThat(info.memberId()).isEqualTo(2L);
+        assertThat(info.order()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("remove 메소드는 세션 정보를 삭제한다")
+    void remove_session() {
+        registry.register("s1", 1L, 2L, 3L);
+        registry.remove("s1");
+        assertThat(registry.get("s1")).isNull();
+    }
+
+    @Test
+    @DisplayName("canPassMembersSessionId 메소드는 티켓에 속한 세션 아이디를 반환한다")
+    void can_pass_members_session_id() {
+        registry.register("s1", 1L, 2L, 3L);
+        registry.register("s2", 1L, 3L, 4L);
+        registry.register("s3", 2L, 4L, 5L);
+
+        List<String> ids = registry.canPassMembersSessionId(1L);
+        assertThat(ids).containsExactlyInAnyOrder("s1", "s2");
+    }
+}

--- a/backend/queue-server/src/test/resources/application.yml
+++ b/backend/queue-server/src/test/resources/application.yml
@@ -8,6 +8,7 @@ spring:
 wait:
   queue:
     pass-chunk-size: 4
+    ttl-seconds: 2
 
 jwt:
   secret: "testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest"


### PR DESCRIPTION
## 📄 작업 설명
대기열 서버를 Http Polling에서 WebSocket으로 변경하였어요.
각 인스턴스 노드에서 세션을 통해 해당 멤버와 TicketId, 순서표를 Map에 저장해 Redis stream을 통해서 순서표 업데이트를 브로드캐스트 받고, 입장 순서인 멤버를 구매 가능 Set에 넣도록 로직을 구현했어요.
따라서 api-server 모듈에 있는 purchase 과정 시 해당 유저가 구매 가능 Set에 있는지 체크 하는 과정을 통해서 유효성 검사를 진행해요 !

## 🚨 관련 이슈
closes #23 

## 🌈 작업 상황
- Redis Stream을 통한 queue-server, queue-manager-server 통신 기능 구현
- 대기열 큐를 위한 웹소켓 컨트롤러 메서드 구현
- 각 인스턴스 노드의 대기열 구현 및 순서에 따른 구매 가능 Set 추가 구현

## 📌 기타
